### PR TITLE
ci: fix temp .flake8 file used with ci-syntax.sh

### DIFF
--- a/.github/scripts/.flake8
+++ b/.github/scripts/.flake8
@@ -1,8 +1,3 @@
 [flake8]
+ignore = W191,E101,E265,E203
 max-line-length = 120
-exclude =
-    DEFw,
-    .git,
-    __pycache__,
-    build,
-    dist


### PR DESCRIPTION
Fix format issues in the local file (.github/scripts/.flake8)

Signed-off-by: Thomas Naughton <naughtont@ornl.gov>
