### PR TITLE
Add QRMI/QDMI bifurcation front-end (svc_lib_qpm) + design doc

### DIFF
--- a/backends/qfw_qiskit/qfw_lookup_service.py
+++ b/backends/qfw_qiskit/qfw_lookup_service.py
@@ -1,5 +1,54 @@
 import logging
-from defw_app_util import defw_get_resource_mgr, defw_reserve_service_by_name
+import os
+from time import sleep
+
+import defw
+from defw_app_util import defw_get_resource_mgr, SYSTEM_UP_TIMEOUT
+from defw_exception import DEFwReserveError
+
+# Which QPM implementation to use when more than one is registered for the
+# same device. The resmgr matches QPMs on name+type+caps only and ignores
+# service properties (see DEFwServiceInfo.is_match), so the native service
+# (svc_iqm_qpm, provider 'iqm') and the QRMI/QDMI shim (svc_lib_qpm,
+# provider 'shim') advertise an identical triple and both come back from
+# get_services. We disambiguate here on the advertised 'provider' property:
+#   QFW_QPM_IMPL=iqm   -> native IQM service (default)
+#   QFW_QPM_IMPL=shim  -> QRMI/QDMI bifurcation front-end
+QPM_IMPL_ENV = "QFW_QPM_IMPL"
+DEFAULT_QPM_IMPL = "iqm"
+
+
+def _reserve_qpm(rmgr, qpm_type, qpm_cap, timeout=SYSTEM_UP_TIMEOUT):
+	want = os.environ.get(QPM_IMPL_ENV, DEFAULT_QPM_IMPL)
+
+	infos = []
+	wait = 0
+	while wait < timeout:
+		infos = rmgr.get_services('QPM', qpm_type, qpm_cap)
+		if infos:
+			break
+		wait += 1
+		logging.debug("Waiting to connect to QPM")
+		sleep(1)
+	if not infos:
+		raise DEFwReserveError(
+			f"Couldn't connect to a QPM ({qpm_type}, {qpm_cap})")
+
+	# resmgr matching ignores properties, so select the requested impl on the
+	# 'provider' property here. Fall back to whatever matched if the requested
+	# impl isn't registered (e.g. only one of native/shim is loaded).
+	chosen = [i for i in infos if i.get_properties().get('provider') == want]
+	if chosen:
+		logging.debug(
+			f"selected QPM impl '{want}' "
+			f"({len(chosen)} of {len(infos)} match(es))")
+	else:
+		logging.debug(
+			f"no QPM with provider '{want}'; using first of "
+			f"{len(infos)} match(es)")
+		chosen = infos
+
+	return defw.connect_to_resource(chosen, 'QPM')[0]
 
 
 def test_qpm(qpm_api):
@@ -10,7 +59,7 @@ def test_qpm(qpm_api):
 def get_qpm(qpm_type=-1, qpm_cap=-1):
 	#Grab a qpm if one exists
 	rmgr = defw_get_resource_mgr()
-	qpm_api = defw_reserve_service_by_name(rmgr, 'QPM', qpm_type, qpm_cap)[0]
+	qpm_api = _reserve_qpm(rmgr, qpm_type, qpm_cap)
 
 	logging.debug(f"got the qpm {qpm_api}")
 

--- a/docs/hld.md
+++ b/docs/hld.md
@@ -12,6 +12,7 @@
 | [QFw Runtime Integration](#qfw-runtime-integration) |
 | [QFw Scheduler Integration](#qfw-scheduler-integration) |
 | [Implementation Plan](#implementation-plan) |
+| [QPU Front-End Contract](qpu-frontend-contract.md) |
 
 ## Overview
 

--- a/docs/qpu-frontend-contract.md
+++ b/docs/qpu-frontend-contract.md
@@ -76,7 +76,7 @@ negotiation and a concurrency rule **per facet**.
 | Facet | Consumed by | QRMI | QDMI | Concurrency rule | Routing rule |
 |---|---|---|---|---|---|
 | Resource Management | SLURM + SPANK | rich (acquire/release) | session-based | single session | session owner |
-| Device Introspection | applications | thin | rich | freely composable | per-call; overlaps by preference |
+| Device Introspection | applications | yes (via `target()`) | rich (session) | freely composable | per-call; overlaps by preference |
 | Execution | applications | provider-defined | rich | single library, whole transaction | bound to session owner |
 
 The QRMI/QDMI columns here are **representative**; because each library is itself
@@ -167,8 +167,8 @@ Multiple QPU resources plug in below QRMI (IBM Quantum, Pasqal, …) — exactly
 providers plug into **libfabric** — and QDMI has per-device drivers below it
 (e.g. QDMI-on-IQM). A capability therefore belongs to the **resource-plus-library
 leaf**, not to "QRMI" or "QDMI" as a whole: QRMI's coverage for an IBM Heron
-differs from a Pasqal device, and QRMI has no IQM provider today (so IQM is
-reached via QDMI / QDMI-on-IQM).
+differs from a Pasqal or IQM device, each reached through its own QRMI provider
+(for IQM, `qrmi.qiskit_iqm`).
 
 Consequence: **there is one descriptor and one capability map per resource.** The
 per-library columns shown in Sections 3, 6, and 9 are *illustrative*; the
@@ -177,8 +177,9 @@ authoritative capabilities are always read from the resource's own descriptor.
 In the implementation (Section 10) the `Frontend` is built **per resource** from
 its descriptor and routes on `descriptor.caps`; a driver's static `CAPABILITIES`
 is only the full set of calls that library can serve, which the descriptor narrows. So the same code yields a
-different capability map per deployment — `get_device_info` resolves to QDMI on
-the IQM q20 but is a NULL-out on a QRMI-only resource where QDMI isn't wired.
+different capability map per deployment — `get_device_info` is composable on the
+IQM q20 (QDMI preferred, QRMI serves it too) and resolves to QRMI on a
+QRMI-only resource, while a call no wired library covers is a NULL-out.
 
 ## 6. Call surfaces by facet
 
@@ -199,13 +200,15 @@ the IQM q20 but is a NULL-out on a QRMI-only resource where QDMI isn't wired.
 
 | Contract call | QRMI | QDMI |
 |---|---|---|
-| `architecture()` (sites/qubits) | partial (target meta) | rich |
-| `coupling()` | partial | yes |
-| `calibration()` | partial | yes |
-| `operations()` (native gates) | partial | yes |
-| `quality_metrics()` | no | no (NULL today — gap) |
+| `architecture()` (sites/qubits) | yes (via `target()`) | yes (session) |
+| `coupling()` | yes | yes |
+| `calibration()` | yes (via `target()`) | yes (session) |
+| `operations()` (native gates) | yes | yes |
+| `quality_metrics()` | — (future contract growth) | — (future contract growth) |
 
-This is where the preference environment variable applies.
+Both libraries serve this facet (QRMI builds it from `target()`, QDMI from its
+session), so it is genuinely composable and this is where the preference
+environment variable applies.
 
 ### Facet C — Execution (single library, whole transaction; bound to session owner)
 
@@ -255,8 +258,9 @@ Inverting the `caps` matrix across resources produces a vendor scorecard:
 capability         qrmi   qdmi
 acquire/release      x      -    <- QDMI gap: no reservation lifecycle
 accounting           x      -    <- QDMI gap
-coupling/calib       ~      x    <- QRMI gap: thin device introspection
-quality_metrics      -      -    <- neither: user-driven future contract growth
+device/coupling      x      x    <- both introspect the device (composable)
+calibration          ~      x    <- QRMI target() carries it; shim wiring pending
+quality_metrics      -      -    <- neither yet: user-driven future contract growth
 ```
 
 Because it is generated from conformance declarations rather than maintained by

--- a/docs/qpu-frontend-contract.md
+++ b/docs/qpu-frontend-contract.md
@@ -1,0 +1,392 @@
+# QPU Front-End Contract — Design Proposal
+
+Status: **Draft — revised after vendor feedback**
+Author: Doug Oucharek
+Date: 2026-05-27 (revised 2026-06-08)
+
+## 1. Purpose
+
+QFw submits quantum jobs to QPU resources that may be reached through different
+lower-level interface libraries — today **QRMI** (IBM's Rust + C + Python
+resource-management interface) and **QDMI** (the Munich/MQSS C device interface),
+and tomorrow other vendor-specific libraries. SLURM integration is a separate **SPANK-plugin layer**
+that wraps whichever interface drives a resource — not built into either
+(Section 11).
+
+This document proposes a **common front-end** that sits between QFw's QPM
+service layer and those libraries. The front-end is a **contract between users
+of QPU resources and the vendors that supply them**:
+
+- Any capability a user needs is added to the front-end.
+- Vendors then implement that capability in their chosen library (QRMI, QDMI,
+  or other), or leave it unimplemented (NULL).
+
+### Goals
+
+- **Upper layers never change.** SLURM and the SPANK plugins must not be
+  modified as new QPU resources or vendor libraries are added. All
+  interface variance is absorbed by the front-end through capability
+  negotiation.
+- **Union, not intersection.** The contract exposes the *superset* of calls
+  that make sense across libraries, not the lowest common denominator.
+  Unimplemented calls are NULL-ed out per resource.
+- **A path to a standard — not another permanent layer.** The front-end is an
+  *implementation-first* contract (the libfabric/OFI model): a working reference
+  that evolves through real use and can later be codified into an open
+  *specification* each vendor implements directly (the MPI model), at which point
+  the shim retires. The capability map shows where the API must grow; it is
+  **not** a lever to force vendors' codebases to merge. See Section 14.
+
+### Non-goals
+
+- Replacing QRMI or QDMI. The front-end orchestrates them; it does not
+  reimplement them.
+- Hardware-faithful performance modeling (that remains out of scope for the
+  QFw-SLURM-Cluster environment generally).
+
+## 2. Core idea: a union contract with capability negotiation
+
+Most abstraction layers expose only what every backend supports (the
+intersection). This proposal does the opposite: it exposes the **union** and
+makes **capability negotiation a first-class, mandatory part of the contract**
+so that callers can ask "does this resource support X?" *before* calling X.
+
+The contract therefore has three co-equal halves:
+
+1. **Capability descriptor** — what a given resource/library actually
+   implements.
+2. **Call surface** — the union of function signatures.
+3. **Data schemas** — the semantics of payloads. QFw already normalizes
+   provider-native output to a common **`qhw` schema** (today via the
+   `qhw-iqm` / `qhw-data` submodules). NULL-able functions handle *presence*;
+   the qhw schema handles *meaning*. Both are required or the contract drifts.
+
+Adding a capability to the contract is a **spec change** (signature + semantics +
+qhw schema), not merely a code change. That friction is deliberate: it keeps
+the union meaningful and prevents feature sprawl.
+
+## 3. Faceting
+
+SLURM and SPANK do not care about circuits; they care about resource lifecycle
+and accounting. Applications care about device topology, calibration, and
+circuit execution. These concerns map onto the two libraries' respective
+strengths, so the contract is split into **facets**, with capability
+negotiation and a concurrency rule **per facet**.
+
+| Facet | Consumed by | QRMI | QDMI | Concurrency rule | Routing rule |
+|---|---|---|---|---|---|
+| Resource Management | SLURM + SPANK | rich (acquire/release) | session-based | single session | session owner |
+| Device Introspection | applications | thin | rich | freely composable | per-call; overlaps by preference |
+| Execution | applications | provider-defined | rich | single library, whole transaction | bound to session owner |
+
+The QRMI/QDMI columns here are **representative**; because each library is itself
+a multi-provider layer, the real capabilities are **per resource** (Section 5.1).
+SLURM scheduling is **not** a column above — it is a SPANK-plugin layer that
+wraps either interface (Section 11), orthogonal to the QRMI-vs-QDMI choice.
+
+Faceting is what actually delivers the "upper layers never change" guarantee:
+SPANK binds only to the narrow, stable Resource-Management facet, while the
+wide, fast-moving Execution/Introspection surface never touches the scheduler.
+
+## 4. Concurrent composition
+
+The front-end may drive **more than one library concurrently for the same
+resource**, routing each contract call to whichever library implements it. This
+minimizes NULL-outs and yields the gap map (Section 9). The granularity of
+"concurrent," however, differs by facet.
+
+### Safe to compose: read-only / idempotent calls (Introspection)
+
+Topology, coupling, calibration, operations, and quality metrics are read-only
+and idempotent. Even where a library keeps a session with the device (QDMI
+always does — it is **not** stateless), a read does not mutate execution state,
+so:
+
+- Non-overlapping calls route to whichever library has them.
+- Overlapping calls (both expose calibration) are resolved by a **user
+  preference** (environment variable, see Section 6).
+
+### Must stay within one library: stateful execution (Execution + acquisition)
+
+Execution calls are a transaction and share backend state:
+
+- **Job handles are not portable.** A job submitted via QRMI (`task_start`)
+  must be polled and fetched via QRMI (`task_result`); QDMI's job handle lives
+  in a different ID space. They do not interoperate today.
+- **Acquisition binds execution.** QRMI's `acquire`/`release` reserves the QPU,
+  and the SPANK plugin (Section 11) ties that reservation to the SLURM
+  allocation. If the reservation holder is one library but the circuit is
+  submitted through a separate session in another, the work runs *out-of-band*
+  of the reservation and the scheduling/accounting guarantee silently breaks.
+
+Therefore the `acquire → submit → status → result → release` sequence is **one
+transaction in one library**, and that library is dictated by **whoever owns the
+reservation** (`session_owner`), not by per-call preference. If no library
+implements `acquire` (a pure device with no reservation concept), the binding is
+free and falls through to preference.
+
+### Cost control: lazy second library
+
+Running two libraries means two auth contexts, two connections, and two failure
+modes. The second library is therefore **instantiated lazily** — only when the
+primary NULLs a call the user actually requested — so the common single-library
+case stays cheap.
+
+## 5. The capability descriptor
+
+Every resource carries a descriptor. Upper layers and applications read the
+descriptor instead of knowing which vendor library is underneath.
+
+```yaml
+resource:
+  id: ornl-iqm-20q
+  provider: iqm
+  contract_version: 1
+  libraries: [qrmi, qdmi]          # which are wired for this resource
+  preference: qdmi                 # tiebreaker for composable overlaps (env-overridable)
+  facets:
+    resource_mgmt:
+      session_owner: qrmi          # owner of acquire() — binds execution
+      caps: { is_accessible: qrmi, acquire: qrmi, release: qrmi,
+              status: [qrmi, qdmi], accounting: qrmi, target_meta: [qrmi, qdmi] }
+    introspection:
+      caps: { architecture: qdmi, coupling: qdmi, calibration: [qdmi, qrmi],
+              operations: qdmi, quality_metrics: NULL }
+    execution:
+      bound_to: resource_mgmt.session_owner   # = qrmi here
+      caps: { submit: qrmi, status: qrmi, result: qrmi, cancel: qrmi, wait: qrmi }
+```
+
+`NULL` means no wired library implements the capability — a gap-map entry.
+A list (e.g. `[qdmi, qrmi]`) means composable; preference breaks the tie.
+
+### 5.1 Capabilities are per resource — libfabric-style providers
+
+QRMI and QDMI are not monolithic; each is **itself a multi-provider layer**.
+Multiple QPU resources plug in below QRMI (IBM Quantum, Pasqal, …) — exactly as
+providers plug into **libfabric** — and QDMI has per-device drivers below it
+(e.g. QDMI-on-IQM). A capability therefore belongs to the **resource-plus-library
+leaf**, not to "QRMI" or "QDMI" as a whole: QRMI's coverage for an IBM Heron
+differs from a Pasqal device, and QRMI has no IQM provider today (so IQM is
+reached via QDMI / QDMI-on-IQM).
+
+Consequence: **there is one descriptor and one capability map per resource.** The
+per-library columns shown in Sections 3, 6, and 9 are *illustrative*; the
+authoritative capabilities are always read from the resource's own descriptor.
+
+In the implementation (Section 10) the `Frontend` is built **per resource** from
+its descriptor and routes on `descriptor.caps`; a driver's static `CAPABILITIES`
+is only the full set of calls that library can serve, which the descriptor narrows. So the same code yields a
+different capability map per deployment — `get_device_info` resolves to QDMI on
+the IQM q20 but is a NULL-out on a QRMI-only resource where QDMI isn't wired.
+
+## 6. Call surfaces by facet
+
+### Facet A — Resource Management (single session; routed to session owner)
+
+| Contract call | QRMI | QDMI | NULL-out behavior |
+|---|---|---|---|
+| `is_accessible()` | yes | partial (status) | sentinel `NOT_IMPLEMENTED` |
+| `acquire() -> lease` | yes | no | NULL -> no-op, returns ambient handle |
+| `release(lease)` | yes | no | NULL -> no-op |
+| `status()` | yes | yes | composable (read-only) |
+| `accounting()` | yes | no | NULL |
+| `target_meta()` | yes | yes | composable |
+
+`acquire()` sets the binding for the Execution facet.
+
+### Facet B — Device Introspection (freely composable; per-call, overlaps by preference)
+
+| Contract call | QRMI | QDMI |
+|---|---|---|
+| `architecture()` (sites/qubits) | partial (target meta) | rich |
+| `coupling()` | partial | yes |
+| `calibration()` | partial | yes |
+| `operations()` (native gates) | partial | yes |
+| `quality_metrics()` | no | no (NULL today — gap) |
+
+This is where the preference environment variable applies.
+
+### Facet C — Execution (single library, whole transaction; bound to session owner)
+
+| Contract call | QRMI | QDMI |
+|---|---|---|
+| `submit(circuit, shots, opts) -> job` | `task_start` | submit |
+| `status(job)` | `task_status` | status |
+| `result(job) -> qhw_result` | `task_result` | get_result |
+| `cancel(job)` | `task_stop` | cancel |
+| `wait(job, timeout)` | poll | poll |
+
+The whole sequence runs in one library; job handles do not cross libraries.
+
+## 7. Uniform return semantics
+
+Every contract call returns one of a fixed, vendor-neutral set — never a
+vendor-specific error. This is what keeps the upper layers stable.
+
+- `OK(payload)` — payload always in the **qhw schema**, regardless of source
+  library.
+- `NOT_IMPLEMENTED` — no wired library covers this capability (the gap-map
+  signal).
+- `NOT_ACQUIRED` — an execution call arrived before `acquire()` on a resource
+  whose RM facet requires a lease.
+- `UNSUPPORTED_INPUT` — a circuit form the bound library cannot accept and the
+  front-end cannot transcode.
+
+SLURM/SPANK only ever branch on these states; they never see `iqm` vs `qrmi`
+vs `qdmi`.
+
+## 8. Circuit-in / result-out normalization
+
+- **In:** the contract carries a canonical circuit form; the descriptor
+  declares what each library ingests; the front-end transcodes. (This
+  generalizes today's QASM -> `iqm.pulse` step in
+  `services/svc_iqm_qpm/util_iqm.py`.)
+- **Out:** every `result()` is normalized to the existing **qhw schema** via a
+  per-library normalizer (`qhw-qdmi`, `qhw-qrmi`) modeled on today's
+  `qhw-iqm`. This invariant keeps the `backends/qfw_qiskit` primitives and the
+  statevector contract untouched.
+
+## 9. The gap map
+
+Inverting the `caps` matrix across resources produces a vendor scorecard:
+
+```
+capability         qrmi   qdmi
+acquire/release      x      -    <- QDMI gap: no reservation lifecycle
+accounting           x      -    <- QDMI gap
+coupling/calib       ~      x    <- QRMI gap: thin device introspection
+quality_metrics      -      -    <- neither: user-driven future contract growth
+```
+
+Because it is generated from conformance declarations rather than maintained by
+hand, the gap map shows **where the API must grow** and, ultimately, **what an
+eventual open specification should standardize** (Section 14). It is computed
+**per resource** (Section 5.1): the columns above are illustrative, and the same
+library can show a different profile depending on which QPU is plugged in below
+it. The map informs the specification; it does not force vendors' codebases
+together.
+
+## 10. Where this lands in QFw
+
+The shim is a **new, separate QPM service that runs in parallel** to the native
+IQM service — *not* an in-place modification of `svc_iqm_qpm`. The native path
+is deliberately left untouched so it remains available as a reference
+implementation to evaluate the shim against.
+
+- **`service-apis/api_qpm`** is left as-is to start; it is the contract both
+  services implement, and is fine-tuned later as the shim matures.
+- **`services/svc_iqm_qpm/` is unchanged** — `svc_qrc.py` keeps hard-
+  instantiating `IQMServiceClient()`. It is the native, single-vendor
+  implementation, kept in parallel for evaluation.
+- **New service `services/svc_lib_qpm/`** (the bifurcation layer) implements the
+  same `api_qpm` surface and owns the routing decision per Sections 4–6. Routing
+  is **descriptor-driven and per-resource**: for each call the candidate
+  libraries are `descriptor.caps[call]` ∩ *wired libraries* ∩ *the calls the driver serves*.
+  Among those candidates, an execution call (`run_circuit` and its job
+  timing/metadata lookups) always goes to the library that holds the
+  reservation; otherwise, when more than one library can serve the call, a
+  configurable preference picks one. Registered as a peer in
+  `setup/qfw_services.yaml`
+  (`shim-ornl-20q`), selectable instead of the native `iqm-ornl-20q`.
+  - `descriptor.py` — the per-resource descriptor (Section 5) and
+    `resolve_descriptor(device_id)`. Returns a built-in default today; intended
+    to read `dev-config/config.yaml` per device, with optional dynamic
+    refinement (Section 12.2).
+  - `frontend.py` — the `Frontend`, **built per resource from a descriptor**;
+    routes via `descriptor.caps`, exposes a per-resource `capability_map()`, and
+    raises `NotImplementedByLibrary` (the NOT_IMPLEMENTED / gap-map signal) when
+    no wired library covers a call for that resource.
+  - `svc_qrc.py` — its own run-queue (mirrors the native one); resolves the
+    descriptor, constructs only the **wired** drivers, and drives the `Frontend`
+    instead of `IQMServiceClient`.
+  - `drivers/` — `QrmiDriver`, `QdmiDriver`. Each declares a static
+    `CAPABILITIES` set — the **full set of calls that library can serve** — which
+    the per-resource descriptor narrows. Lower-level libraries
+    are imported lazily, so the service constructs and routes before any real
+    library call is made.
+- **`dev-config/config.yaml`** (resolved via `services/util/device_access.py`)
+  gains `libraries:`, `preference:`, and per-resource `caps:` — the persistent
+  source for `resolve_descriptor()`, replacing the built-in default.
+- **Result normalizers** `qhw-qdmi` / `qhw-qrmi` are added alongside the
+  existing `qhw-iqm` to keep the qhw schema stable.
+- The second library is instantiated lazily.
+
+The de-facto driver contract already exists implicitly as the public method set
+of `IQMServiceClient` (`get_device_info`, `get_backend_info`,
+`get_dynamic_backend_info`, `get_coupling_graph`, `get_calibration_snapshot`,
+`run_circuit`, `get_last_job_timing`, `get_last_job_metadata`). Each shim
+driver's `CAPABILITIES` declares which of these calls its library *can* cover;
+the per-resource descriptor declares which actually
+apply to a given resource. Promoting the method set to an explicit
+`QFwDeviceDriver` protocol is a later refinement.
+
+## 11. SLURM / SPANK fit
+
+The QFw-SLURM-Cluster already models QPUs as GRES on the quantum partition:
+nodes `c5`–`c8` carry `Gres=qpu:N Features=iqm,superconducting,q20` in
+`slurm.conf`. A **SPANK plugin** maps a reservation onto this GRES model and is
+the contract surface SLURM binds to (the narrow, stable Resource-Management
+facet).
+
+Crucially, that SPANK plugin is a **separate layer that wraps whichever
+interface drives the resource** — it is *not* built into QRMI or QDMI. QRMI
+ships a SPANK plugin today; a QDMI one is emerging (e.g. PSNC's SLURM HPC plugin
+for an AQT system via QDMI, `gitlab.pcss.pl/quantum/psnc-sdk/slurm-hpc-plugin`).
+So SLURM scheduling is **orthogonal to the QRMI-vs-QDMI choice** — it sits above
+both, alongside the shim, and the shim never makes scheduling a per-library
+concern.
+
+## 12. Open decisions
+
+1. **Canonical circuit form** — OpenQASM3 vs QIR. Affects every driver's
+   transcoder.
+2. **Capability discovery** — static (declared in config) vs dynamic (queried
+   from the library at bind time). QDMI can self-report; QRMI metadata is more
+   static. The descriptor must pick a model or absorb both.
+3. **Preference scope** — a single global `QFW_QPU_IFACE_PREF`, or per-facet
+   (e.g. allow preference for Introspection but never for Execution, which is
+   reservation-bound regardless).
+4. **Contract definition language** — a language-neutral spec (IDL + schema)
+   from day one, versus a Python-first prototype with the spec extracted later.
+   Only a language-neutral definition can serve as the open specification that
+   QRMI (Rust + C + Python) and QDMI (C) each implement against (Section 14).
+
+## 13. Suggested first milestone
+
+Implement **Device Introspection only** through both shims —
+`get_device_info` / `coupling()` — before touching execution. This exercises
+the factory, the descriptor, capability negotiation, and qhw normalization
+without the job-lifecycle and reservation-binding complexity.
+
+## 14. Strategic positioning: implementation-first to a specification
+
+Vendors are wary of "yet another interface." The two ways to standardize a
+multi-vendor API frame the choice:
+
+- **Specification-first (the MPI model)** — agree a spec up front; each vendor
+  owns and ships its own implementation. Vendors keep control, but it is hard to
+  specify an API nobody has battle-tested, and design-by-committee is slow.
+- **Implementation-first (the libfabric / OFI model)** — ship one working
+  implementation; through real use it becomes the de-facto contract, and a
+  standard once adoption grows.
+
+This proposal takes the **implementation-first** path *as a route to* the
+specification the vendors want, reconciling both camps:
+
+1. **Implement (now).** The front-end (this contract) lives in the QFw repo as a
+   working implementation. We drive QRMI + QDMI on IQM, experiment, and evolve
+   the API against real workloads. The capability map (Section 9) is grown from
+   real conformance.
+2. **Converge.** As the API proves out, the implementation becomes the de-facto
+   contract and QRMI/QDMI can **align their APIs** to it. (Convergence here means
+   the *APIs* align on a shared surface — each vendor keeps its own
+   implementation; this is **not** a codebase merger.)
+3. **Specify.** Codify the proven API as an **open specification**. Vendors
+   implement the spec directly — each owning its build, MPI-style — and the
+   **shim retires**: it was scaffolding to find the right contract, not a
+   permanent layer.
+
+The end state is exactly what the vendors asked for — a specification they each
+implement — reached via a working reference that de-risks it. The QFw shim is a
+**means, not an end.**

--- a/services/svc_lib_qpm/__init__.py
+++ b/services/svc_lib_qpm/__init__.py
@@ -1,0 +1,72 @@
+from .svc_qpm import QPM
+import defw
+import os
+import threading
+import logging
+from time import sleep
+import util.qpm.util_qpm as uq
+
+SERVICE_NAME = 'QPM'
+SERVICE_DESC = 'Quantum Platform Manager (QRMI/QDMI shim)'
+
+# This is used by the infrastructure to display information about
+# the service module. The name is also used as a key through out the
+# infrastructure. Without it the service module will not load.
+svc_info = {
+	'name': SERVICE_NAME,
+	'module': __name__,
+	'description': SERVICE_DESC,
+	'version': 1.0,
+	'properties': {
+		'provider': 'shim',
+		'num_qubits': 20,
+	}
+}
+
+# This is used by the infrastructure to define all the service classes.
+# Each class should be a separate service. Each class should implement the
+# following methods:
+#	query()
+#	reserve()
+#	release()
+service_classes = [QPM]
+
+
+def qpm_complete_init():
+	uq.qpm_initialized = True
+	logging.debug("Shim QPM Initialized Successfully")
+
+
+def qpm_wait_resmgr():
+	while not defw.resmgr and not uq.qpm_shutdown:
+		logging.debug("still waiting for resmgr to come up")
+		sleep(1)
+	if not uq.qpm_shutdown:
+		qpm_complete_init()
+
+
+def initialize():
+	global g_timeout
+
+	if uq.qpm_initialized:
+		return
+
+	try:
+		g_timeout = int(os.environ['QFW_STARTUP_TIMEOUT'])
+	except (KeyError, ValueError):
+		g_timeout = 40
+
+	if not defw.resmgr:
+		# we haven't connected to the resmgr yet. Spin up a thread and
+		# wait for it to connect before finishing up the initialization
+		svc_qpm_thr = threading.Thread(target=qpm_wait_resmgr, args=())
+		svc_qpm_thr.daemon = True
+		svc_qpm_thr.start()
+		return
+
+	qpm_complete_init()
+
+
+def uninitialize():
+	uq.qpm_shutdown = True
+	logging.debug("Shim QPM shutdown")

--- a/services/svc_lib_qpm/descriptor.py
+++ b/services/svc_lib_qpm/descriptor.py
@@ -13,10 +13,17 @@ import os
 
 QPU_DEVICE_ENV = "QFW_QPU_DEVICE_ID"
 
-# Default descriptor for the ORNL IQM q20: introspection via QDMI, execution
-# via QRMI (the reservation owner). caps[call] = libraries that cover that call
-# FOR THIS RESOURCE. A list of length > 1 is a composable overlap broken by
-# preference; an empty list (or missing key) is a NULL-out / gap-map entry.
+# Default descriptor for the ORNL IQM q20. Device introspection is a
+# COMPOSABLE facet: both QRMI (via QuantumResource.target()) and QDMI serve it,
+# with QDMI preferred (it introspects without holding a reservation, while
+# QRMI's target() is reservation-bound). Execution is QRMI's (the reservation
+# owner). caps[call] = libraries that cover that call FOR THIS RESOURCE. A list
+# of length > 1 is a composable overlap broken by preference; an empty list (or
+# missing key) is a NULL-out / gap-map entry.
+#
+# get_calibration_snapshot / get_dynamic_backend_info stay QDMI-only here for
+# now; QRMI's target() also carries that data (calibration_set / dynamic
+# architecture), so wiring QRMI for them is a follow-up.
 _DEFAULT_DESCRIPTORS = {
 	"ornl-iqm-20q": {
 		"id": "ornl-iqm-20q",
@@ -25,8 +32,8 @@ _DEFAULT_DESCRIPTORS = {
 		"preference": "qdmi",
 		"execution_owner": "qrmi",
 		"caps": {
-			"get_device_info":          ["qdmi"],
-			"get_coupling_graph":       ["qdmi"],
+			"get_device_info":          ["qdmi", "qrmi"],
+			"get_coupling_graph":       ["qdmi", "qrmi"],
 			"get_calibration_snapshot": ["qdmi"],
 			"get_dynamic_backend_info": ["qdmi"],
 			"get_backend_info":         ["qdmi", "qrmi"],

--- a/services/svc_lib_qpm/descriptor.py
+++ b/services/svc_lib_qpm/descriptor.py
@@ -1,0 +1,59 @@
+# Per-resource capability descriptor (design doc qpu-frontend-contract.md
+# section 5). Capability belongs to the resource-plus-library leaf, not to a
+# library as a whole — so the Frontend is built per resource from one of these.
+#
+# Today resolve_descriptor() returns a built-in default for the IQM q20.
+# The intended source is dev-config/config.yaml (per device_id), resolved via
+# services/util/device_access.py (design doc section 10); dynamic per-resource
+# refinement (querying the library at bind time) is the open decision in
+# section 12.2. The default keeps the routing layer descriptor-driven now.
+
+import logging
+import os
+
+QPU_DEVICE_ENV = "QFW_QPU_DEVICE_ID"
+
+# Default descriptor for the ORNL IQM q20: introspection via QDMI, execution
+# via QRMI (the reservation owner). caps[call] = libraries that cover that call
+# FOR THIS RESOURCE. A list of length > 1 is a composable overlap broken by
+# preference; an empty list (or missing key) is a NULL-out / gap-map entry.
+_DEFAULT_DESCRIPTORS = {
+	"ornl-iqm-20q": {
+		"id": "ornl-iqm-20q",
+		"provider": "iqm",
+		"libraries": ["qrmi", "qdmi"],
+		"preference": "qdmi",
+		"execution_owner": "qrmi",
+		"caps": {
+			"get_device_info":          ["qdmi"],
+			"get_coupling_graph":       ["qdmi"],
+			"get_calibration_snapshot": ["qdmi"],
+			"get_dynamic_backend_info": ["qdmi"],
+			"get_backend_info":         ["qdmi", "qrmi"],
+			"run_circuit":              ["qrmi"],
+			"get_last_job_timing":      ["qrmi"],
+			"get_last_job_metadata":    ["qrmi"],
+		},
+	},
+}
+
+# Fallback for an unknown device id: wire both libraries with the same coarse
+# introspection-QDMI / execution-QRMI split.
+_FALLBACK = _DEFAULT_DESCRIPTORS["ornl-iqm-20q"]
+
+
+def resolve_descriptor(device_id=None):
+	"""Return the per-resource descriptor for `device_id`.
+
+	TODO: read libraries/preference/caps from dev-config/config.yaml per
+	device_id (design doc section 10), and optionally refine via dynamic
+	discovery (section 12.2). For now this returns a built-in default so the
+	Frontend is descriptor-driven from the start.
+	"""
+	device_id = device_id or os.environ.get(QPU_DEVICE_ENV, "ornl-iqm-20q")
+	desc = _DEFAULT_DESCRIPTORS.get(device_id)
+	if desc is None:
+		logging.debug(
+			"shim: no descriptor for %r; using fallback", device_id)
+		desc = dict(_FALLBACK, id=device_id)
+	return desc

--- a/services/svc_lib_qpm/drivers/__init__.py
+++ b/services/svc_lib_qpm/drivers/__init__.py
@@ -1,0 +1,8 @@
+# Shim drivers: each adapts one lower-level library to the QFw front-end
+# contract and declares its capabilities. The Frontend (../frontend.py) routes
+# each contract call to whichever driver implements it.
+
+from .qrmi_driver import QrmiDriver
+from .qdmi_driver import QdmiDriver
+
+__all__ = ["QrmiDriver", "QdmiDriver"]

--- a/services/svc_lib_qpm/drivers/base_driver.py
+++ b/services/svc_lib_qpm/drivers/base_driver.py
@@ -1,0 +1,23 @@
+# Base class for shim drivers. A driver adapts one lower-level library
+# (QRMI, QDMI, …) to the QFw front-end contract and declares which contract
+# calls it implements (its capability set). Unimplemented calls are NULL-ed
+# out — the Frontend never routes a call to a driver that does not implement it.
+
+from defw_exception import DEFwExecutionError
+
+
+class BaseDriver:
+	# Subclasses set `name` (the library key used for routing/preference) and
+	# `CAPABILITIES` (the subset of contract calls they cover).
+	name = "base"
+	CAPABILITIES = frozenset()
+
+	def implements(self, call):
+		return call in self.CAPABILITIES
+
+	def _pending(self, call, lib):
+		# Routing is wired; binding the call to the concrete library is the
+		# next milestone (docs/qpu-frontend-contract.md §13).
+		raise DEFwExecutionError(
+			f"{self.name}.{call}: routing wired; binding to {lib} is the "
+			"next milestone")

--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -1,0 +1,64 @@
+# QDMI driver — routes the front-end's device-introspection calls to QDMI
+# (IQM's QDMI-on-IQM implementation, exposed as the `iqm.qdmi` Python package).
+#
+# QDMI is session-based and strong on device & calibration introspection, so
+# this driver declares the introspection calls. Execution/job calls are left
+# to QRMI (the reservation owner) in the default wiring.
+
+from .base_driver import BaseDriver
+from defw_exception import DEFwExecutionError
+import logging
+
+
+class QdmiDriver(BaseDriver):
+	name = "qdmi"
+	CAPABILITIES = frozenset({
+		"get_backend_info",
+		"get_device_info",
+		"get_dynamic_backend_info",
+		"get_calibration_snapshot",
+		"get_coupling_graph",
+	})
+
+	def __init__(self, descriptor=None):
+		# Per-resource descriptor (descriptor.py); carries device identity for
+		# binding/creds and, later, dynamic capability discovery.
+		self._descriptor = descriptor
+		self._qdmi = None
+
+	def _client(self):
+		# Lazy import so the service/Frontend construct and route even where
+		# iqm-qdmi is not importable; only a real call needs the library.
+		if self._qdmi is None:
+			try:
+				from iqm import qdmi
+			except Exception as exc:
+				raise DEFwExecutionError(
+					"failed to import iqm.qdmi (QDMI-on-IQM). Install "
+					f"iqm-qdmi before using the QDMI driver: {exc}") from exc
+			self._qdmi = qdmi
+			logging.debug("shim: QDMI (iqm.qdmi) client initialized")
+		return self._qdmi
+
+	# --- introspection (routing wired; hardware binding to iqm.qdmi is the
+	#     next milestone — docs/qpu-frontend-contract.md §13) -------------
+
+	def get_device_info(self):
+		self._client()
+		return self._pending("get_device_info", "iqm.qdmi")
+
+	def get_coupling_graph(self, calibration_set_id=None):
+		self._client()
+		return self._pending("get_coupling_graph", "iqm.qdmi")
+
+	def get_backend_info(self):
+		self._client()
+		return self._pending("get_backend_info", "iqm.qdmi")
+
+	def get_dynamic_backend_info(self, calibration_set_id=None):
+		self._client()
+		return self._pending("get_dynamic_backend_info", "iqm.qdmi")
+
+	def get_calibration_snapshot(self, calibration_set_id=None):
+		self._client()
+		return self._pending("get_calibration_snapshot", "iqm.qdmi")

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -1,8 +1,17 @@
-# QRMI driver — routes the front-end's execution + resource-management calls
-# to QRMI (IBM's Rust + C + Python resource-management interface; the `qrmi`
-# Python package). QRMI owns the reservation lifecycle, so it is the default
-# execution owner; it also exposes backend/target metadata, which overlaps
-# with QDMI (a composable tie broken by preference).
+# QRMI driver — execution/reservation owner that ALSO serves device
+# introspection.
+#
+# QRMI (IBM's Rust + C + Python resource-management interface; the `qrmi`
+# package) owns the reservation lifecycle, so it is the default execution
+# owner. It also exposes the device target: QuantumResource.target() returns
+# vendor-unique QPU configuration & properties (coupling map, basis gates,
+# qubit properties), confirmed by IBM. So device introspection is NOT
+# QDMI-exclusive -- it is a composable facet QRMI serves too, broken by
+# preference.
+#
+# Routing for get_device_info / get_coupling_graph is wired to QRMI here;
+# binding them to the real QRMI backend is the next milestone
+# (docs/qpu-frontend-contract.md §13).
 
 from .base_driver import BaseDriver
 from defw_exception import DEFwExecutionError
@@ -12,6 +21,8 @@ import logging
 class QrmiDriver(BaseDriver):
 	name = "qrmi"
 	CAPABILITIES = frozenset({
+		"get_device_info",       # QRMI target() -> device topology (composable)
+		"get_coupling_graph",    # QRMI target() -> connectivity (composable)
 		"get_backend_info",      # QRMI target/metadata (composable with QDMI)
 		"run_circuit",
 		"get_last_job_timing",
@@ -37,6 +48,17 @@ class QrmiDriver(BaseDriver):
 			self._qrmi = qrmi
 			logging.debug("shim: QRMI client initialized")
 		return self._qrmi
+
+	# --- introspection facet (routing wired; QRMI binding is the next
+	#     milestone — docs/qpu-frontend-contract.md §13) -----------------
+
+	def get_device_info(self):
+		self._resource()
+		return self._pending("get_device_info", "qrmi")
+
+	def get_coupling_graph(self, calibration_set_id=None):
+		self._resource()
+		return self._pending("get_coupling_graph", "qrmi")
 
 	# --- execution + metadata (routing wired; hardware binding to qrmi is
 	#     the next milestone — docs/qpu-frontend-contract.md §13) ---------

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -1,0 +1,58 @@
+# QRMI driver — routes the front-end's execution + resource-management calls
+# to QRMI (IBM's Rust + C + Python resource-management interface; the `qrmi`
+# Python package). QRMI owns the reservation lifecycle, so it is the default
+# execution owner; it also exposes backend/target metadata, which overlaps
+# with QDMI (a composable tie broken by preference).
+
+from .base_driver import BaseDriver
+from defw_exception import DEFwExecutionError
+import logging
+
+
+class QrmiDriver(BaseDriver):
+	name = "qrmi"
+	CAPABILITIES = frozenset({
+		"get_backend_info",      # QRMI target/metadata (composable with QDMI)
+		"run_circuit",
+		"get_last_job_timing",
+		"get_last_job_metadata",
+	})
+
+	def __init__(self, descriptor=None):
+		# Per-resource descriptor (descriptor.py); carries device identity for
+		# binding/creds and, later, dynamic capability discovery.
+		self._descriptor = descriptor
+		self._qrmi = None
+
+	def _resource(self):
+		# Lazy import so the service/Frontend construct and route even where
+		# the qrmi package is not importable; only a real call needs it.
+		if self._qrmi is None:
+			try:
+				import qrmi
+			except Exception as exc:
+				raise DEFwExecutionError(
+					"failed to import qrmi. Install the qrmi Python package "
+					f"before using the QRMI driver: {exc}") from exc
+			self._qrmi = qrmi
+			logging.debug("shim: QRMI client initialized")
+		return self._qrmi
+
+	# --- execution + metadata (routing wired; hardware binding to qrmi is
+	#     the next milestone — docs/qpu-frontend-contract.md §13) ---------
+
+	def get_backend_info(self):
+		self._resource()
+		return self._pending("get_backend_info", "qrmi")
+
+	def run_circuit(self, circuit):
+		self._resource()
+		return self._pending("run_circuit", "qrmi")
+
+	def get_last_job_timing(self, cid=None):
+		self._resource()
+		return self._pending("get_last_job_timing", "qrmi")
+
+	def get_last_job_metadata(self, cid=None):
+		self._resource()
+		return self._pending("get_last_job_metadata", "qrmi")

--- a/services/svc_lib_qpm/frontend.py
+++ b/services/svc_lib_qpm/frontend.py
@@ -1,0 +1,145 @@
+# QPU front-end shim — bifurcation layer for svc_lib_qpm.
+#
+# This service is QFw's *own implementation* of the front-end contract: a
+# separate, parallel QPM service (alongside the native svc_iqm_qpm, which is
+# left untouched for evaluation). It implements the api_qpm surface and
+# internally routes each contract call to QRMI or QDMI.
+#
+# Routing is driven by a PER-RESOURCE descriptor (descriptor.py; design doc
+# qpu-frontend-contract.md sections 5 and 5.1), not by a fixed per-library
+# table. For a call, the candidate libraries are:
+#
+#     descriptor.caps[call]  ∩  wired libraries  ∩  driver.implements(call)
+#
+# i.e. what the resource's descriptor says covers the call, restricted to the
+# libraries wired for this resource, restricted to the calls the driver can
+# actually serve (its static CAPABILITIES). Among the
+# candidates:
+#   1. execution-family calls pin to the reservation/execution owner;
+#   2. otherwise, if more than one, an explicit preference breaks the tie
+#      (QFW_QPU_IFACE_PREF overrides the descriptor's preference);
+#   3. otherwise the first candidate.
+
+from defw_exception import DEFwExecutionError
+import logging
+import os
+
+VERSION = 0.3
+
+PREFERENCE_ENV = "QFW_QPU_IFACE_PREF"
+
+# The contract is the union of operations (today: the IQMServiceClient surface).
+CONTRACT_CALLS = (
+	"get_backend_info",
+	"get_device_info",
+	"get_dynamic_backend_info",
+	"get_calibration_snapshot",
+	"get_coupling_graph",
+	"run_circuit",
+	"get_last_job_timing",
+	"get_last_job_metadata",
+)
+
+# Execution-family calls share backend state and must stay within one library
+# — the reservation/execution owner — never split by per-call preference.
+EXECUTION_CALLS = frozenset({
+	"run_circuit",
+	"get_last_job_timing",
+	"get_last_job_metadata",
+})
+
+
+class NotImplementedByLibrary(DEFwExecutionError):
+	"""No wired library implements a requested contract call for this resource
+	(the NOT_IMPLEMENTED / gap-map signal)."""
+
+
+class Frontend:
+	def __init__(self, drivers, descriptor):
+		# drivers: iterable of driver objects, each exposing `.name`,
+		#   `.implements(call)`, and the contract methods it covers.
+		# descriptor: the per-resource capability descriptor (descriptor.py).
+		self._drivers = {}
+		for d in drivers:
+			self._drivers[d.name] = d
+		if not self._drivers:
+			raise DEFwExecutionError("Frontend requires at least one driver")
+
+		self._id = descriptor.get("id")
+		self._caps = descriptor.get("caps", {})
+		# Libraries wired for this resource (default: whatever drivers exist).
+		self._wired = set(descriptor.get("libraries", self._drivers.keys()))
+		# Preference (composable tiebreaker): env var overrides the descriptor.
+		self._preference = (os.environ.get(PREFERENCE_ENV)
+				or descriptor.get("preference"))
+		# Reservation/execution owner: from the descriptor, else first wired
+		# library that can run a circuit.
+		self._execution_owner = (descriptor.get("execution_owner")
+				or self._default_exec_owner())
+
+	def _default_exec_owner(self):
+		for name in self._wired:
+			d = self._drivers.get(name)
+			if d and d.implements("run_circuit"):
+				return name
+		return None
+
+	# --- routing -----------------------------------------------------
+
+	def _candidates(self, call):
+		# per-resource caps  ∩  wired libraries  ∩  calls the driver can serve
+		return [n for n in self._caps.get(call, [])
+				if n in self._wired
+				and n in self._drivers
+				and self._drivers[n].implements(call)]
+
+	def route(self, call):
+		"""Return the driver chosen to handle `call` (the routing decision)."""
+		cands = self._candidates(call)
+		if not cands:
+			raise NotImplementedByLibrary(
+				f"no wired library implements {call!r} for "
+				f"resource {self._id!r}")
+		if call in EXECUTION_CALLS and self._execution_owner in cands:
+			return self._drivers[self._execution_owner]
+		if len(cands) == 1:
+			return self._drivers[cands[0]]
+		if self._preference in cands:
+			return self._drivers[self._preference]
+		# stable default: first candidate listed in the descriptor
+		return self._drivers[cands[0]]
+
+	def _dispatch(self, call, *args, **kwargs):
+		driver = self.route(call)
+		logging.debug("shim: routing %s -> %s", call, driver.name)
+		return getattr(driver, call)(*args, **kwargs)
+
+	def capability_map(self):
+		"""Per-resource gap map: which wired libraries cover each call."""
+		return {call: self._candidates(call) for call in CONTRACT_CALLS}
+
+	# --- contract surface (delegates to the routed driver) -----------
+
+	def get_backend_info(self):
+		return self._dispatch("get_backend_info")
+
+	def get_device_info(self):
+		return self._dispatch("get_device_info")
+
+	def get_dynamic_backend_info(self, calibration_set_id=None):
+		return self._dispatch("get_dynamic_backend_info", calibration_set_id)
+
+	def get_calibration_snapshot(self, calibration_set_id=None):
+		return self._dispatch("get_calibration_snapshot", calibration_set_id)
+
+	def get_coupling_graph(self, calibration_set_id=None):
+		return self._dispatch("get_coupling_graph", calibration_set_id)
+
+	def run_circuit(self, circuit):
+		return self._dispatch("run_circuit", circuit)
+
+	def get_last_job_timing(self, cid=None):
+		return self._dispatch("get_last_job_timing", cid)
+
+	def get_last_job_metadata(self, cid=None):
+		return self._dispatch("get_last_job_metadata", cid)

--- a/services/svc_lib_qpm/svc_qpm.py
+++ b/services/svc_lib_qpm/svc_qpm.py
@@ -1,0 +1,61 @@
+import logging
+import os
+from .svc_qrc import QRC
+from util.qpm.util_qpm import UTIL_QPM
+from util.qpm.util_circuit import set_max_qubits_pp
+
+MAX_SHIM_QUBITS = 1024
+
+
+class QPM(UTIL_QPM):
+	def __init__(self, start=True):
+		super().__init__(QRC(start=start), max_ppn=1, start=start)
+		set_max_qubits_pp(MAX_SHIM_QUBITS)
+
+	def query(self):
+		from . import SERVICE_NAME, SERVICE_DESC, svc_info
+		from api_qpm import QPMType, QPMCapability
+		properties = dict(svc_info.get('properties', {}))
+		device_id = os.environ.get('QFW_QPU_DEVICE_ID')
+		if device_id:
+			properties['device_id'] = device_id
+		info = self.query_helper(
+			QPMType.QPM_TYPE_IQM | QPMType.QPM_TYPE_HARDWARE,
+			QPMCapability.QPM_CAP_SUPERCONDUCTING,
+			SERVICE_NAME, SERVICE_DESC,
+			properties=properties)
+		logging.debug(f"shim {SERVICE_DESC}: {info}")
+		return info
+
+	def create_circuit(self, info):
+		# Hardware is still the IQM q20 (reached via QRMI / QDMI-on-IQM), so the
+		# qhw backend tag stays 'iqm' until per-library normalizers land.
+		info['qfw_backend'] = 'iqm'
+		return super().create_circuit(info)
+
+	def capability_map(self):
+		return self.qrc.capability_map()
+
+	def get_backend_info(self):
+		return self.qrc.get_backend_info()
+
+	def get_device_info(self):
+		return self.qrc.get_device_info()
+
+	def get_dynamic_backend_info(self, calibration_set_id=None):
+		return self.qrc.get_dynamic_backend_info(calibration_set_id)
+
+	def get_calibration_snapshot(self, calibration_set_id=None):
+		return self.qrc.get_calibration_snapshot(calibration_set_id)
+
+	def get_coupling_graph(self, calibration_set_id=None):
+		return self.qrc.get_coupling_graph(calibration_set_id)
+
+	def get_last_job_timing(self, cid=None):
+		return self.qrc.get_last_job_timing(cid)
+
+	def get_last_job_metadata(self, cid=None):
+		return self.qrc.get_last_job_metadata(cid)
+
+	def test(self):
+		return "****Shim (QRMI/QDMI) QPM Test Successful****"

--- a/services/svc_lib_qpm/svc_qrc.py
+++ b/services/svc_lib_qpm/svc_qrc.py
@@ -1,0 +1,149 @@
+# Run-queue for the shim service (svc_lib_qpm). Same sync/async execution and
+# results bookkeeping as the native IQM run-queue, but every driver call goes
+# through the bifurcation Frontend, which routes it to QRMI or QDMI.
+
+from api_events import Event
+from defw_exception import DEFwExecutionError
+from .descriptor import resolve_descriptor
+from .frontend import Frontend
+from .drivers.qrmi_driver import QrmiDriver
+from .drivers.qdmi_driver import QdmiDriver
+import logging
+import threading
+import time
+
+_DRIVER_FACTORY = {"qrmi": QrmiDriver, "qdmi": QdmiDriver}
+
+
+class QRC:
+	def __init__(self, start=True):
+		self.shutdown_workers = False
+		self.circuit_results = []
+		self.circuit_results_lock = threading.Lock()
+		self.push_info = {}
+		self.threads = []
+		# Per-resource descriptor drives the bifurcation: only the libraries
+		# wired for this resource get a driver, and the Frontend routes each
+		# call per the descriptor's caps (QFW_QPU_IFACE_PREF breaks ties).
+		descriptor = resolve_descriptor()
+		drivers = [_DRIVER_FACTORY[name](descriptor)
+				for name in descriptor.get("libraries", [])
+				if name in _DRIVER_FACTORY]
+		self.frontend = Frontend(drivers, descriptor)
+
+	def _result_dict(self, circ, output, rc):
+		return {
+			'cid': circ.get_cid(),
+			'result': output,
+			'rc': rc,
+			'launch_time': circ.launch_time,
+			'creation_time': circ.creation_time,
+			'exec_time': circ.exec_time,
+			'completion_time': circ.completion_time,
+			'resources_consumed_time': circ.resources_consumed_time,
+			'cq_enqueue_time': time.time(),
+			'cq_dequeue_time': -1
+		}
+
+	def _push_or_store_result(self, result):
+		if self.push_info:
+			event = Event(self.push_info['evtype'], result)
+			try:
+				self.push_info['class'].put(event)
+			except Exception as e:
+				logging.critical(
+					"Failed to push event to client. "
+					f"Exception encountered {e}")
+				raise e
+			return
+
+		with self.circuit_results_lock:
+			self.circuit_results.append(result)
+
+	def _run_circuit(self, circ, raise_on_error):
+		try:
+			circ.set_launching()
+			circ.set_running()
+			output = self.frontend.run_circuit(circ)
+			circ.set_exec_done()
+			return self._result_dict(circ, output, 0)
+		except Exception as e:
+			circ.set_fail()
+			if raise_on_error:
+				raise DEFwExecutionError(str(e)) from e
+			logging.critical(f"shim circuit {circ.get_cid()} failed: {e}")
+			output = {
+				'counts': {},
+				'shim': {
+					'error': str(e),
+					'error_type': type(e).__name__,
+				},
+			}
+			return self._result_dict(circ, output, -1)
+
+	def _async_runner(self, circ):
+		try:
+			result = self._run_circuit(circ, raise_on_error=False)
+		finally:
+			circ.free_resources(circ)
+		self._push_or_store_result(result)
+
+	def sync_run(self, circ):
+		return self._run_circuit(circ, raise_on_error=True)
+
+	def async_run(self, circ):
+		cid = circ.get_cid()
+		runner = threading.Thread(target=self._async_runner, args=(circ,))
+		runner.daemon = True
+		runner.start()
+		self.threads.append(runner)
+		return cid
+
+	def read_cq(self, cid=None):
+		with self.circuit_results_lock:
+			for index, result in enumerate(self.circuit_results):
+				if cid is None or result['cid'] == cid:
+					result = self.circuit_results.pop(index)
+					result['cq_dequeue_time'] = time.time()
+					return result
+		return None
+
+	def peak_cq(self, cid=None):
+		with self.circuit_results_lock:
+			for result in self.circuit_results:
+				if cid is None or result['cid'] == cid:
+					return result
+		return None
+
+	def register_event_notification(self, info):
+		self.push_info = info
+
+	def capability_map(self):
+		return self.frontend.capability_map()
+
+	def get_backend_info(self):
+		return self.frontend.get_backend_info()
+
+	def get_device_info(self):
+		return self.frontend.get_device_info()
+
+	def get_dynamic_backend_info(self, calibration_set_id=None):
+		return self.frontend.get_dynamic_backend_info(calibration_set_id)
+
+	def get_calibration_snapshot(self, calibration_set_id=None):
+		return self.frontend.get_calibration_snapshot(calibration_set_id)
+
+	def get_coupling_graph(self, calibration_set_id=None):
+		return self.frontend.get_coupling_graph(calibration_set_id)
+
+	def get_last_job_timing(self, cid=None):
+		return self.frontend.get_last_job_timing(cid)
+
+	def get_last_job_metadata(self, cid=None):
+		return self.frontend.get_last_job_metadata(cid)
+
+	def shutdown(self):
+		self.shutdown_workers = True
+		for thread in self.threads:
+			if thread.is_alive():
+				thread.join(timeout=1)

--- a/setup/qfw_services.yaml
+++ b/setup/qfw_services.yaml
@@ -21,3 +21,13 @@ services:
     agent-prefix: qpm_iqm
     target: group1-head
     device-id: ornl-iqm-20q
+
+  # QRMI/QDMI bifurcation shim — parallel to svc_iqm_qpm, same IQM q20 device
+  # reached via QRMI / QDMI-on-IQM. Select this instead of iqm-ornl-20q to
+  # drive the resource through the shim.
+  - name: shim-ornl-20q
+    module: svc_lib_qpm
+    load-modules: svc_lib_qpm,api_launcher
+    agent-prefix: qpm_shim
+    target: group1-head
+    device-id: ornl-iqm-20q


### PR DESCRIPTION
Introduce a front-end "shim" that lets QFw drive a QPU through either QRMI or QDMI, implemented as a new QPM service running in parallel with the native IQM path.

- docs/qpu-frontend-contract.md: design proposal for a per-resource, union-not-intersection contract that routes each call to whichever library implements it; linked from the HLD table of contents (docs/hld.md).
- services/svc_lib_qpm/: new QPM service implementing api_qpm. A descriptor-driven Frontend routes per resource (descriptor caps, narrowed by the wired libraries and each driver's structural ceiling), pins execution to the reservation owner, and breaks composable ties on QFW_QPU_IFACE_PREF; NotImplementedByLibrary is the gap-map signal. Includes its own run-queue and QrmiDriver/QdmiDriver.
- Library calls are stubbed for now: routing is wired and tested, but the concrete QRMI/QDMI bindings (and dynamic capability discovery) are the next milestone.
- Native svc_iqm_qpm and api_qpm are left unchanged, so the shim runs in parallel as a reference implementation for evaluation.
- backends/qfw_qiskit/qfw_lookup_service.py: select the implementation via QFW_QPM_IMPL (default = native iqm), since the resmgr matches QPMs on name+type+caps only and ignores properties.
- setup/qfw_services.yaml: register the shim as a peer service (shim-ornl-20q)

Signed-off-by: Doug Oucharek <dougso@me.com>