### PR TITLE
QFw: wire device introspection through the shim (QDMI + QRMI)

### DIFF
--- a/docs/qpu-frontend-contract.md
+++ b/docs/qpu-frontend-contract.md
@@ -356,12 +356,36 @@ concern.
    Only a language-neutral definition can serve as the open specification that
    QRMI (Rust + C + Python) and QDMI (C) each implement against (Section 14).
 
-## 13. Suggested first milestone
+## 13. First milestone: Device Introspection
 
-Implement **Device Introspection only** through both shims —
-`get_device_info` / `coupling()` — before touching execution. This exercises
-the factory, the descriptor, capability negotiation, and qhw normalization
-without the job-lifecycle and reservation-binding complexity.
+**Status: implemented.** The Device Introspection facet — `get_device_info`
+and `get_coupling_graph` (`coupling()`) — is wired end to end through the shim
+ahead of any execution work. This exercises the driver factory, the
+per-resource descriptor, capability negotiation, and qhw normalization without
+the job-lifecycle and reservation-binding complexity.
+
+It is a **composable** facet: both libraries serve it, so it is wired for both.
+Each opens the IQM device as a Qiskit `BackendV2` — QDMI via
+`iqm.qdmi.qiskit.IQMBackend`, QRMI via `qrmi.qiskit_iqm.IQMProvider().get_backend()`
+(QRMI's `target()` carries the device configuration) — and a shared, pure
+adapter (`drivers/backend_normalize.py`) normalizes that backend's topology
+into the provider-neutral `qhw-device-v1` / `qhw-coupling-v1` records,
+regardless of which library produced the backend. That is the same schema the
+native IQM path emits via `qhw-iqm`, so a consumer sees one shape no matter
+which library served the call. Splitting extraction (the only Qiskit-touching
+step) from the record builders keeps normalization testable without hardware.
+In the default IQM q20 descriptor both calls list `[qdmi, qrmi]` and the
+preference (QDMI) wins; on a QRMI-only resource they resolve to QRMI. The QDMI
+driver resolves connection settings from the same source as the native service
+(`QFW_QC_URL` / `QFW_API_KEY` / `QFW_IQM_QUANTUM_COMPUTER`, then
+`util.device_access`); the QRMI driver reads QRMI's own resource environment
+(populated by the SPANK plugin inside a reservation).
+
+Still stubbed for later milestones: execution (`run_circuit` and its job
+timing/metadata, which stay with the QRMI reservation owner) and the remaining
+introspection calls (`get_backend_info`, dynamic/calibration snapshots — QRMI's
+`target()` also carries calibration/dynamic data, so wiring those is a natural
+follow-up).
 
 ## 14. Strategic positioning: implementation-first to a specification
 

--- a/docs/qpu-frontend-contract.md
+++ b/docs/qpu-frontend-contract.md
@@ -364,22 +364,25 @@ ahead of any execution work. This exercises the driver factory, the
 per-resource descriptor, capability negotiation, and qhw normalization without
 the job-lifecycle and reservation-binding complexity.
 
-It is a **composable** facet: both libraries serve it, so it is wired for both.
-Each opens the IQM device as a Qiskit `BackendV2` — QDMI via
-`iqm.qdmi.qiskit.IQMBackend`, QRMI via `qrmi.qiskit_iqm.IQMProvider().get_backend()`
-(QRMI's `target()` carries the device configuration) — and a shared, pure
-adapter (`drivers/backend_normalize.py`) normalizes that backend's topology
-into the provider-neutral `qhw-device-v1` / `qhw-coupling-v1` records,
-regardless of which library produced the backend. That is the same schema the
-native IQM path emits via `qhw-iqm`, so a consumer sees one shape no matter
-which library served the call. Splitting extraction (the only Qiskit-touching
-step) from the record builders keeps normalization testable without hardware.
+It is a **composable** facet: both libraries serve it, so it is wired for both —
+but they are normalized differently, because they expose different things. QDMI
+presents the device as a *vendor-neutral* Qiskit `BackendV2`
+(`iqm.qdmi.qiskit.IQMBackend`) with no raw IQM data, so the QDMI driver reads
+the topology off the `Target` and normalizes it with a small adapter
+(`drivers/backend_normalize.py`). QRMI's `QuantumResource.target()` returns the
+*raw IQM data* (dynamic architecture / calibration / quality sets), so the QRMI
+driver feeds that straight to **`qhw-iqm`** — the same normalizer the native
+`svc_iqm_qpm` path uses. Either way the output is the same provider-neutral
+`qhw-device-v1` / `qhw-coupling-v1`, so a consumer sees one shape no matter which
+library served the call.
+
 In the default IQM q20 descriptor both calls list `[qdmi, qrmi]` and the
 preference (QDMI) wins; on a QRMI-only resource they resolve to QRMI. The QDMI
 driver resolves connection settings from the same source as the native service
 (`QFW_QC_URL` / `QFW_API_KEY` / `QFW_IQM_QUANTUM_COMPUTER`, then
-`util.device_access`); the QRMI driver reads QRMI's own resource environment
-(populated by the SPANK plugin inside a reservation).
+`util.device_access`); the QRMI driver opens a `QuantumResource` for that alias
+and reads QRMI's own resource environment (populated by the SPANK plugin inside
+a reservation; `target()` itself is not reservation-bound).
 
 Still stubbed for later milestones: execution (`run_circuit` and its job
 timing/metadata, which stay with the QRMI reservation owner) and the remaining

--- a/services/svc_lib_qpm/drivers/backend_normalize.py
+++ b/services/svc_lib_qpm/drivers/backend_normalize.py
@@ -1,0 +1,174 @@
+# Qiskit BackendV2 -> qhw normalization for the device-introspection facet.
+#
+# Both lower-level libraries expose an IQM device as a Qiskit BackendV2:
+# QDMI-on-IQM via iqm.qdmi.qiskit.IQMBackend, and QRMI via
+# qrmi.qiskit_iqm.IQMProvider().get_backend(). The introspection milestone
+# (design doc qpu-frontend-contract.md section 13) reads the device topology off
+# that backend -- whichever library produced it -- and normalizes it into the
+# provider-neutral qhw-data schema, the same shape the native IQM path emits via
+# qhw-iqm, so a consumer sees one device/coupling record regardless of which
+# library served the call.
+#
+# The module is split into two layers so normalization is testable without
+# hardware or credentials:
+#   - extract_topology(backend): the only part that touches a live Qiskit
+#     BackendV2 (duck-typed: num_qubits, coupling_map, target);
+#   - to_device_record / to_coupling_record: pure functions over the extracted
+#     dict, building qhw-device-v1 / qhw-coupling-v1 with the qhw_data builders.
+#
+# qhw_data is imported lazily inside the record builders (as the native IQM
+# path defers qhw-iqm) so the drivers import and the Frontend routes even where
+# qhw-data is not installed; only a real introspection call needs it.
+
+# Where in the Qiskit backend each piece of the graph was read from --
+# recorded in the qhw coupling record's `source` for provenance.
+_COUPLING_MAP_SOURCE = "backend.coupling_map"
+_OPERATION_LOCI_SOURCE = "backend.target.operations.*.loci"
+
+
+def extract_topology(backend):
+	"""Read a provider-neutral topology dict off a Qiskit BackendV2.
+
+	Returns a dict with:
+	  num_qubits: int
+	  qubits:     list[str]  -- qubit ids ("0".."n-1", BackendV2 indices)
+	  edges:      list[[str, str]]  -- undirected, de-duplicated coupling edges
+	  operations: dict[str, list[list[str]]]  -- gate name -> supported loci
+
+	Only this function depends on the Qiskit backend object; everything else
+	in this module is pure and can be exercised with a synthetic topology dict.
+	"""
+	num_qubits = int(getattr(backend, "num_qubits", 0) or 0)
+	qubits = [str(q) for q in range(num_qubits)]
+	operations = _operations(backend)
+	edges = _coupling_edges(backend, operations)
+	return {
+		"num_qubits": num_qubits,
+		"qubits": qubits,
+		"edges": edges,
+		"operations": operations,
+	}
+
+
+def to_device_record(topo, provider, device_id, include_raw=False,
+		validate=True):
+	"""Build a `qhw-device-v1` record from an extracted topology dict."""
+	from qhw_data import new_device
+	qubits = topo.get("qubits") or []
+	builder = (
+		new_device(provider, device_id, num_qubits=len(qubits))
+		.device(device_id, num_qubits=len(qubits))
+		.qubits(qubits)
+		.metadata({"source": "qdmi", "via": "iqm.qdmi.qiskit"})
+	)
+	if include_raw:
+		builder.raw_payload(topo, format="qdmi-qiskit-topology")
+	return builder.build(validate_schema=validate)
+
+
+def to_coupling_record(topo, provider, device_id, include_raw=False,
+		validate=True):
+	"""Build a `qhw-coupling-v1` record from an extracted topology dict."""
+	from qhw_data import new_coupling
+	qubits = topo.get("qubits") or []
+	edges = topo.get("edges") or []
+	operations = topo.get("operations") or {}
+
+	sources = []
+	if edges:
+		sources.append(_COUPLING_MAP_SOURCE)
+	builder = (
+		new_coupling(provider, device_id, num_qubits=len(qubits),
+				directed=False)
+		.nodes(qubits)
+		.coupling(edges, directed=False, nodes=qubits, source=sources)
+		.metadata({"source": "qdmi", "via": "iqm.qdmi.qiskit"})
+	)
+	for name, loci in sorted(operations.items()):
+		arity = max((len(locus) for locus in loci), default=0)
+		builder.operation(name, arity, supported_loci=loci)
+	if include_raw:
+		builder.raw_payload(topo, format="qdmi-qiskit-topology")
+	return builder.build(validate_schema=validate)
+
+
+# --- backend extraction helpers (Qiskit BackendV2, duck-typed) -----------
+
+def _operations(backend):
+	target = getattr(backend, "target", None)
+	if target is None:
+		return {}
+	try:
+		names = list(target.operation_names)
+	except Exception:
+		return {}
+	operations = {}
+	for name in names:
+		operations[name] = _operation_loci(target, name)
+	return operations
+
+
+def _operation_loci(target, name):
+	# target[name] maps qargs tuples -> InstructionProperties; qargs is None
+	# for global/variadic instructions (no specific locus).
+	try:
+		qargs_map = target[name]
+	except Exception:
+		return []
+	loci = []
+	seen = set()
+	for qargs in (qargs_map or {}):
+		if not qargs:
+			continue
+		locus = [str(q) for q in qargs]
+		key = tuple(locus)
+		if key not in seen:
+			seen.add(key)
+			loci.append(locus)
+	return sorted(loci, key=_locus_key)
+
+
+def _coupling_edges(backend, operations):
+	# Prefer the backend's coupling map; fall back to the two-qubit operation
+	# loci (mirrors how qhw-iqm derives connectivity when none is declared).
+	pairs = []
+	cmap = getattr(backend, "coupling_map", None)
+	if cmap is not None:
+		try:
+			raw = cmap.get_edges()
+		except AttributeError:
+			raw = list(cmap)
+		for edge in raw:
+			edge = list(edge)
+			if len(edge) == 2:
+				pairs.append((str(edge[0]), str(edge[1])))
+	if not pairs:
+		for loci in operations.values():
+			for locus in loci:
+				if len(locus) == 2:
+					pairs.append((locus[0], locus[1]))
+	return _undirected_unique(pairs)
+
+
+def _undirected_unique(pairs):
+	seen = set()
+	unique = []
+	for a, b in pairs:
+		key = tuple(sorted((a, b), key=_qubit_key))
+		if key not in seen:
+			seen.add(key)
+			unique.append([a, b])
+	return sorted(unique, key=lambda edge: (_qubit_key(edge[0]),
+			_qubit_key(edge[1])))
+
+
+def _qubit_key(value):
+	# Natural sort so "10" orders after "2" rather than lexicographically.
+	text = str(value)
+	if text.isdigit():
+		return (0, int(text), "")
+	return (1, 0, text)
+
+
+def _locus_key(locus):
+	return tuple(_qubit_key(q) for q in locus)

--- a/services/svc_lib_qpm/drivers/backend_normalize.py
+++ b/services/svc_lib_qpm/drivers/backend_normalize.py
@@ -1,12 +1,13 @@
 # Qiskit BackendV2 -> qhw normalization for the device-introspection facet.
 #
-# Both lower-level libraries expose an IQM device as a Qiskit BackendV2:
-# QDMI-on-IQM via iqm.qdmi.qiskit.IQMBackend, and QRMI via
-# qrmi.qiskit_iqm.IQMProvider().get_backend(). The introspection milestone
-# (design doc qpu-frontend-contract.md section 13) reads the device topology off
-# that backend -- whichever library produced it -- and normalizes it into the
-# provider-neutral qhw-data schema, the same shape the native IQM path emits via
-# qhw-iqm, so a consumer sees one device/coupling record regardless of which
+# Used by the QDMI driver: QDMI-on-IQM (iqm.qdmi.qiskit.IQMBackend) is a
+# vendor-neutral Qiskit BackendV2 with no raw IQM data to reuse, so its topology
+# is read straight off the Target and normalized here. (The QRMI driver does
+# NOT use this module: QRMI's target() returns raw IQM data, which it feeds to
+# qhw-iqm directly — the same normalizer the native svc_iqm_qpm path uses.)
+#
+# The output is the same provider-neutral qhw-data schema the native IQM path
+# emits, so a consumer sees one device/coupling record regardless of which
 # library served the call.
 #
 # The module is split into two layers so normalization is testable without

--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -1,13 +1,23 @@
-# QDMI driver — routes the front-end's device-introspection calls to QDMI
-# (IQM's QDMI-on-IQM implementation, exposed as the `iqm.qdmi` Python package).
+# QDMI driver — device-introspection facet, wired to QDMI-on-IQM.
 #
-# QDMI is session-based and strong on device & calibration introspection, so
-# this driver declares the introspection calls. Execution/job calls are left
-# to QRMI (the reservation owner) in the default wiring.
+# QDMI-on-IQM exposes an IQM device as a Qiskit BackendV2
+# (iqm.qdmi.qiskit.IQMBackend). QDMI is session-based and strong on device &
+# calibration introspection, so this driver declares the introspection calls.
+# Execution/job calls stay with QRMI (the reservation owner) in the default
+# wiring.
+#
+# Milestone status (design doc qpu-frontend-contract.md section 13): the
+# introspection facet's get_device_info / get_coupling_graph now make real
+# QDMI calls and normalize the device topology into the provider-neutral qhw
+# schema. The remaining introspection calls (backend/calibration snapshots)
+# are wired for routing; binding them to QDMI is a later milestone, and
+# execution stays with QRMI.
 
 from .base_driver import BaseDriver
+from .backend_normalize import extract_topology, to_coupling_record, to_device_record
 from defw_exception import DEFwExecutionError
 import logging
+import os
 
 
 class QdmiDriver(BaseDriver):
@@ -23,42 +33,86 @@ class QdmiDriver(BaseDriver):
 	def __init__(self, descriptor=None):
 		# Per-resource descriptor (descriptor.py); carries device identity for
 		# binding/creds and, later, dynamic capability discovery.
-		self._descriptor = descriptor
-		self._qdmi = None
+		self._descriptor = descriptor or {}
+		self._backend_obj = None
 
-	def _client(self):
-		# Lazy import so the service/Frontend construct and route even where
-		# iqm-qdmi is not importable; only a real call needs the library.
-		if self._qdmi is None:
+	# --- QDMI session / device binding -------------------------------
+
+	def _access(self):
+		# Resolve connection settings for the QDMI-on-IQM backend. Honor the
+		# same env vars the native svc_iqm_qpm uses, then fall back to the
+		# shared device-access config (util.device_access). Returns the kwargs
+		# IQMBackend understands (base_url / token / qc_alias).
+		provider = self._descriptor.get("provider", "iqm")
+		base_url = os.environ.get("QFW_QC_URL")
+		token = os.environ.get("QFW_API_KEY")
+		qc_alias = os.environ.get("QFW_IQM_QUANTUM_COMPUTER")
+		if not (base_url and token):
 			try:
-				from iqm import qdmi
+				from util.device_access import resolve_device_access
+				cfg = resolve_device_access(provider=provider)
 			except Exception as exc:
 				raise DEFwExecutionError(
-					"failed to import iqm.qdmi (QDMI-on-IQM). Install "
-					f"iqm-qdmi before using the QDMI driver: {exc}") from exc
-			self._qdmi = qdmi
-			logging.debug("shim: QDMI (iqm.qdmi) client initialized")
-		return self._qdmi
+					"QDMI driver could not resolve device access for "
+					f"provider {provider!r}: set QFW_QC_URL/QFW_API_KEY or "
+					f"configure device access: {exc}") from exc
+			base_url = base_url or cfg.get("url")
+			token = token or cfg.get("api_key")
+			qc_alias = qc_alias or cfg.get("quantum_computer")
+		return {"base_url": base_url, "token": token, "qc_alias": qc_alias}
 
-	# --- introspection (routing wired; hardware binding to iqm.qdmi is the
-	#     next milestone — docs/qpu-frontend-contract.md §13) -------------
+	def _backend(self):
+		# Lazy: open the QDMI-on-IQM Qiskit backend once. Import and
+		# construction are deferred so the service/Frontend build and route
+		# even where iqm-qdmi is absent or credentials are unset; only a real
+		# introspection call needs a live backend.
+		if self._backend_obj is not None:
+			return self._backend_obj
+		try:
+			from iqm.qdmi.qiskit import IQMBackend
+		except Exception as exc:
+			raise DEFwExecutionError(
+				"failed to import iqm.qdmi.qiskit (QDMI-on-IQM). Install "
+				f"iqm-qdmi[qiskit] before using the QDMI driver: {exc}"
+				) from exc
+		access = self._access()
+		kwargs = {key: value for key, value in access.items() if value}
+		try:
+			self._backend_obj = IQMBackend(**kwargs)
+		except Exception as exc:
+			raise DEFwExecutionError(
+				f"failed to open QDMI-on-IQM backend: {exc}") from exc
+		logging.debug("shim: QDMI-on-IQM backend opened (%s)",
+				access.get("qc_alias") or access.get("base_url"))
+		return self._backend_obj
+
+	def _ids(self):
+		return (self._descriptor.get("provider", "iqm"),
+				self._descriptor.get("id", "iqm-device"))
+
+	# --- introspection facet: real QDMI calls (section 13 milestone) -----
 
 	def get_device_info(self):
-		self._client()
-		return self._pending("get_device_info", "iqm.qdmi")
+		provider, device_id = self._ids()
+		topo = extract_topology(self._backend())
+		return to_device_record(topo, provider, device_id)
 
 	def get_coupling_graph(self, calibration_set_id=None):
-		self._client()
-		return self._pending("get_coupling_graph", "iqm.qdmi")
+		provider, device_id = self._ids()
+		topo = extract_topology(self._backend())
+		return to_coupling_record(topo, provider, device_id)
+
+	# --- remaining introspection: routing wired, QDMI binding is a later
+	#     milestone (docs/qpu-frontend-contract.md section 13) -----------
 
 	def get_backend_info(self):
-		self._client()
+		self._backend()
 		return self._pending("get_backend_info", "iqm.qdmi")
 
 	def get_dynamic_backend_info(self, calibration_set_id=None):
-		self._client()
+		self._backend()
 		return self._pending("get_dynamic_backend_info", "iqm.qdmi")
 
 	def get_calibration_snapshot(self, calibration_set_id=None):
-		self._client()
+		self._backend()
 		return self._pending("get_calibration_snapshot", "iqm.qdmi")

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -3,17 +3,21 @@
 #
 # QRMI (IBM's Rust + C + Python resource-management interface; the `qrmi`
 # package) owns the reservation lifecycle, so it is the default execution
-# owner. It also exposes the device target: QuantumResource.target() returns
+# owner. It also exposes the device target: `QuantumResource.target()` returns
 # vendor-unique QPU configuration & properties (coupling map, basis gates,
-# qubit properties), confirmed by IBM. So device introspection is NOT
-# QDMI-exclusive -- it is a composable facet QRMI serves too, broken by
-# preference.
+# qubit properties; for IQM, the dynamic architecture / calibration / quality
+# sets), confirmed by IBM. So introspection is NOT QDMI-exclusive — it is a
+# composable facet, and for an IQM resource QRMI exposes the device as a Qiskit
+# BackendV2 via `qrmi.qiskit_iqm`, the same shape QDMI-on-IQM produces.
 #
-# Routing for get_device_info / get_coupling_graph is wired to QRMI here;
-# binding them to the real QRMI backend is the next milestone
-# (docs/qpu-frontend-contract.md §13).
+# Milestone status (design doc qpu-frontend-contract.md section 13): the
+# device-introspection facet's get_device_info / get_coupling_graph are wired
+# to QRMI here (reusing the shared BackendV2 -> qhw normalizer), so a
+# QRMI-only resource introspects through QRMI. Execution and the richer
+# backend/calibration snapshots remain stubbed for a later milestone.
 
 from .base_driver import BaseDriver
+from .backend_normalize import extract_topology, to_coupling_record, to_device_record
 from defw_exception import DEFwExecutionError
 import logging
 
@@ -21,8 +25,8 @@ import logging
 class QrmiDriver(BaseDriver):
 	name = "qrmi"
 	CAPABILITIES = frozenset({
-		"get_device_info",       # QRMI target() -> device topology (composable)
-		"get_coupling_graph",    # QRMI target() -> connectivity (composable)
+		"get_device_info",       # QRMI target() -> device topology
+		"get_coupling_graph",    # QRMI target() -> connectivity
 		"get_backend_info",      # QRMI target/metadata (composable with QDMI)
 		"run_circuit",
 		"get_last_job_timing",
@@ -32,8 +36,9 @@ class QrmiDriver(BaseDriver):
 	def __init__(self, descriptor=None):
 		# Per-resource descriptor (descriptor.py); carries device identity for
 		# binding/creds and, later, dynamic capability discovery.
-		self._descriptor = descriptor
+		self._descriptor = descriptor or {}
 		self._qrmi = None
+		self._backend_obj = None
 
 	def _resource(self):
 		# Lazy import so the service/Frontend construct and route even where
@@ -49,19 +54,53 @@ class QrmiDriver(BaseDriver):
 			logging.debug("shim: QRMI client initialized")
 		return self._qrmi
 
-	# --- introspection facet (routing wired; QRMI binding is the next
-	#     milestone — docs/qpu-frontend-contract.md §13) -----------------
+	def _backend(self):
+		# Lazy: open QRMI's IQM device as a Qiskit BackendV2 once, for
+		# introspection. QRMI reads its own resource config/credentials from
+		# the environment (the SPANK plugin populates it inside a reservation),
+		# so the provider is constructed without args, as in QRMI's own IQM
+		# examples.
+		if self._backend_obj is not None:
+			return self._backend_obj
+		provider = self._descriptor.get("provider", "iqm")
+		if provider != "iqm":
+			raise DEFwExecutionError(
+				"QRMI introspection is wired for IQM resources via "
+				f"qrmi.qiskit_iqm; provider {provider!r} is not yet supported "
+				"by this driver")
+		try:
+			from qrmi.qiskit_iqm import IQMProvider
+		except Exception as exc:
+			raise DEFwExecutionError(
+				"failed to import qrmi.qiskit_iqm (QRMI IQM backend). Install "
+				f"QRMI with Qiskit IQM support before using QRMI "
+				f"introspection: {exc}") from exc
+		try:
+			self._backend_obj = IQMProvider().get_backend()
+		except Exception as exc:
+			raise DEFwExecutionError(
+				f"failed to open QRMI IQM backend: {exc}") from exc
+		logging.debug("shim: QRMI IQM backend opened")
+		return self._backend_obj
+
+	def _ids(self):
+		return (self._descriptor.get("provider", "iqm"),
+				self._descriptor.get("id", "iqm-device"))
+
+	# --- introspection facet: real QRMI calls (section 13 milestone) -----
 
 	def get_device_info(self):
-		self._resource()
-		return self._pending("get_device_info", "qrmi")
+		provider, device_id = self._ids()
+		topo = extract_topology(self._backend())
+		return to_device_record(topo, provider, device_id)
 
 	def get_coupling_graph(self, calibration_set_id=None):
-		self._resource()
-		return self._pending("get_coupling_graph", "qrmi")
+		provider, device_id = self._ids()
+		topo = extract_topology(self._backend())
+		return to_coupling_record(topo, provider, device_id)
 
-	# --- execution + metadata (routing wired; hardware binding to qrmi is
-	#     the next milestone — docs/qpu-frontend-contract.md §13) ---------
+	# --- execution + metadata (routing wired; binding to qrmi is a later
+	#     milestone — docs/qpu-frontend-contract.md section 13) -----------
 
 	def get_backend_info(self):
 		self._resource()

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -4,29 +4,33 @@
 # QRMI (IBM's Rust + C + Python resource-management interface; the `qrmi`
 # package) owns the reservation lifecycle, so it is the default execution
 # owner. It also exposes the device target: `QuantumResource.target()` returns
-# vendor-unique QPU configuration & properties (coupling map, basis gates,
-# qubit properties; for IQM, the dynamic architecture / calibration / quality
-# sets), confirmed by IBM. So introspection is NOT QDMI-exclusive — it is a
-# composable facet, and for an IQM resource QRMI exposes the device as a Qiskit
-# BackendV2 via `qrmi.qiskit_iqm`, the same shape QDMI-on-IQM produces.
+# the device's RAW IQM data (for IQM: dynamic_quantum_architecture,
+# calibration_set, quality_metrics). So introspection is NOT QDMI-exclusive —
+# it is a composable facet QRMI serves too.
 #
-# Milestone status (design doc qpu-frontend-contract.md section 13): the
-# device-introspection facet's get_device_info / get_coupling_graph are wired
-# to QRMI here (reusing the shared BackendV2 -> qhw normalizer), so a
-# QRMI-only resource introspects through QRMI. Execution and the richer
+# Because that payload is the same IQM data the native svc_iqm_qpm path handles,
+# this driver reuses `qhw-iqm` to normalize it to qhw — rather than a separate
+# adapter. (QDMI is different: it presents a vendor-neutral Qiskit BackendV2
+# with no raw IQM data, so the QDMI driver normalizes from the Target via
+# backend_normalize.) target() is not reservation-bound, so introspection works
+# without acquire().
+#
+# Milestone status (design doc qpu-frontend-contract.md section 13):
+# get_device_info / get_coupling_graph are wired. Execution and the richer
 # backend/calibration snapshots remain stubbed for a later milestone.
 
 from .base_driver import BaseDriver
-from .backend_normalize import extract_topology, to_coupling_record, to_device_record
 from defw_exception import DEFwExecutionError
+import json
 import logging
+import os
 
 
 class QrmiDriver(BaseDriver):
 	name = "qrmi"
 	CAPABILITIES = frozenset({
-		"get_device_info",       # QRMI target() -> device topology
-		"get_coupling_graph",    # QRMI target() -> connectivity
+		"get_device_info",       # QRMI target() -> raw IQM data -> qhw-iqm
+		"get_coupling_graph",    # QRMI target() -> connectivity  -> qhw-iqm
 		"get_backend_info",      # QRMI target/metadata (composable with QDMI)
 		"run_circuit",
 		"get_last_job_timing",
@@ -38,7 +42,7 @@ class QrmiDriver(BaseDriver):
 		# binding/creds and, later, dynamic capability discovery.
 		self._descriptor = descriptor or {}
 		self._qrmi = None
-		self._backend_obj = None
+		self._resource_obj = None
 
 	def _resource(self):
 		# Lazy import so the service/Frontend construct and route even where
@@ -54,50 +58,72 @@ class QrmiDriver(BaseDriver):
 			logging.debug("shim: QRMI client initialized")
 		return self._qrmi
 
-	def _backend(self):
-		# Lazy: open QRMI's IQM device as a Qiskit BackendV2 once, for
-		# introspection. QRMI reads its own resource config/credentials from
-		# the environment (the SPANK plugin populates it inside a reservation),
-		# so the provider is constructed without args, as in QRMI's own IQM
-		# examples.
-		if self._backend_obj is not None:
-			return self._backend_obj
-		provider = self._descriptor.get("provider", "iqm")
-		if provider != "iqm":
-			raise DEFwExecutionError(
-				"QRMI introspection is wired for IQM resources via "
-				f"qrmi.qiskit_iqm; provider {provider!r} is not yet supported "
-				"by this driver")
+	# --- QRMI resource binding ------------------------------------------
+
+	def _qc_alias(self):
+		# IQM resource alias for QuantumResource. Honor the env var the native
+		# svc_iqm_qpm uses, else the shared device-access config.
+		alias = os.environ.get("QFW_IQM_QUANTUM_COMPUTER")
+		if alias:
+			return alias
 		try:
-			from qrmi.qiskit_iqm import IQMProvider
+			from util.device_access import resolve_device_access
+			cfg = resolve_device_access(
+					provider=self._descriptor.get("provider", "iqm"))
+			return cfg.get("quantum_computer")
+		except Exception:
+			return None
+
+	def _qpu(self):
+		# Lazy: open the QRMI QuantumResource for this resource's IQM server.
+		# QRMI reads its own credentials/config from the environment (the SPANK
+		# plugin populates it inside a reservation); target() is not
+		# reservation-bound, so introspection works without acquire().
+		if self._resource_obj is not None:
+			return self._resource_obj
+		qrmi = self._resource()
+		alias = self._qc_alias()
+		if not alias:
+			raise DEFwExecutionError(
+				"QRMI introspection needs an IQM resource alias; set "
+				"QFW_IQM_QUANTUM_COMPUTER or configure device access")
+		try:
+			self._resource_obj = qrmi.QuantumResource(
+					alias, qrmi.ResourceType.IQMServer)
 		except Exception as exc:
 			raise DEFwExecutionError(
-				"failed to import qrmi.qiskit_iqm (QRMI IQM backend). Install "
-				f"QRMI with Qiskit IQM support before using QRMI "
-				f"introspection: {exc}") from exc
+				f"failed to open QRMI IQM resource {alias!r}: {exc}") from exc
+		logging.debug("shim: QRMI IQM resource opened (%s)", alias)
+		return self._resource_obj
+
+	def _iqm_raw(self):
+		# QRMI target() returns raw IQM data; map it to the
+		# {static_architecture, dynamic_architecture} shape qhw-iqm expects.
 		try:
-			self._backend_obj = IQMProvider().get_backend()
+			target = json.loads(self._qpu().target().value)
 		except Exception as exc:
 			raise DEFwExecutionError(
-				f"failed to open QRMI IQM backend: {exc}") from exc
-		logging.debug("shim: QRMI IQM backend opened")
-		return self._backend_obj
+				f"failed to read QRMI target(): {exc}") from exc
+		raw = {"dynamic_architecture":
+				target.get("dynamic_quantum_architecture") or {}}
+		static = target.get("static_quantum_architecture")
+		if static:
+			raw["static_architecture"] = static
+		return raw
 
-	def _ids(self):
-		return (self._descriptor.get("provider", "iqm"),
-				self._descriptor.get("id", "iqm-device"))
-
-	# --- introspection facet: real QRMI calls (section 13 milestone) -----
+	# --- introspection facet: reuse qhw-iqm on QRMI's raw IQM data ------
 
 	def get_device_info(self):
-		provider, device_id = self._ids()
-		topo = extract_topology(self._backend())
-		return to_device_record(topo, provider, device_id)
+		from qhw_iqm import normalize_device
+		return normalize_device(
+				self._iqm_raw(),
+				device_id=self._descriptor.get("id", "iqm-device"))
 
 	def get_coupling_graph(self, calibration_set_id=None):
-		provider, device_id = self._ids()
-		topo = extract_topology(self._backend())
-		return to_coupling_record(topo, provider, device_id)
+		from qhw_iqm import normalize_coupling
+		return normalize_coupling(
+				self._iqm_raw(),
+				device_id=self._descriptor.get("id", "iqm-device"))
 
 	# --- execution + metadata (routing wired; binding to qrmi is a later
 	#     milestone — docs/qpu-frontend-contract.md section 13) -----------


### PR DESCRIPTION
Implements the Device Introspection milestone from the front-end contract (docs/qpu-frontend-contract.md §13): get_device_info and get_coupling_graph now make real calls and normalize the device topology to the provider-neutral qhw schema, ahead of any execution work.

- backend_normalize.py: shared adapter that reads a Qiskit BackendV2's topology (qubits, coupling, operations) into qhw-device-v1 / qhw-coupling-v1 records. Extraction is split from the record builders so normalization is testable without hardware, and qhw-data is imported lazily.
- qdmi_driver: opens the device via QDMI-on-IQM (iqm.qdmi.qiskit.IQMBackend) and normalizes through the shared adapter.
- qrmi_driver: serves the same facet via qrmi.qiskit_iqm, so introspection is composable, not QDMI-exclusive (confirmed with IBM).
- descriptor: get_device_info / get_coupling_graph are [qdmi, qrmi] (composable, QDMI preferred); execution stays with QRMI.
- design doc: §13 marked implemented; §3/§5.1/§6/§9 corrected to show QRMI serving introspection.

Execution and the remaining introspection calls (backend/calibration/dynamic snapshots) stay stubbed for a later milestone.

Signed-off-by: Doug Oucharek <dougso@me.com>