### PR TITLE
QFw: document shape-driven normalization in the contract

### DIFF
--- a/docs/qpu-frontend-contract.md
+++ b/docs/qpu-frontend-contract.md
@@ -245,10 +245,29 @@ vs `qdmi`.
   declares what each library ingests; the front-end transcodes. (This
   generalizes today's QASM -> `iqm.pulse` step in
   `services/svc_iqm_qpm/util_iqm.py`.)
-- **Out:** every `result()` is normalized to the existing **qhw schema** via a
-  per-library normalizer (`qhw-qdmi`, `qhw-qrmi`) modeled on today's
-  `qhw-iqm`. This invariant keeps the `backends/qfw_qiskit` primitives and the
-  statevector contract untouched.
+- **Out:** every contract payload — introspection records today, `result()`
+  later — is normalized to the existing **qhw schema** by a normalizer that is a
+  **separate, pluggable step from the device-access library**. This invariant
+  keeps the `backends/qfw_qiskit` primitives and the statevector contract
+  untouched.
+
+**The normalizer is selected by the *shape* of the data a library returns, not
+by the library itself.** Two shapes cover what we have:
+
+- **Raw vendor data** — a library that hands back its provider's native payload
+  (the native IQM client, and QRMI via `QuantumResource.target()`) is normalized
+  by a provider adapter (`qhw-iqm`), which also captures provider-specific extras
+  such as calibration and quality metrics.
+- **Neutral Qiskit `Target`** — a library that hands back a vendor-neutral
+  `BackendV2` (QDMI-on-IQM, and any future `BackendV2` vendor) is normalized from
+  the `Target` by `drivers/backend_normalize.py`.
+
+This keeps normalization decoupled from the libraries and lets the shim absorb
+both "thick" libraries (raw vendor data) and "thin"/neutral ones (a standard
+`Target`). A *single* universal normalizer would have to be the `Target`-based
+one — it works for any `BackendV2`, whereas `qhw-iqm` is provider-specific —
+which would trade the provider adapter's richer output (calibration/quality) for
+one code path. That trade-off is an open decision (Section 12), not settled here.
 
 ## 9. The gap map
 
@@ -355,6 +374,12 @@ concern.
    from day one, versus a Python-first prototype with the spec extracted later.
    Only a language-neutral definition can serve as the open specification that
    QRMI (Rust + C + Python) and QDMI (C) each implement against (Section 14).
+5. **Normalization strategy** — shape-driven (today: `qhw-iqm` for libraries
+   that expose raw IQM data, `backend_normalize` for those that expose a neutral
+   Qiskit `Target`) versus a single `Target`-based normalizer for all libraries.
+   The latter is uniform and works for any `BackendV2`, but gives up the provider
+   adapter's calibration/quality richness for libraries that could supply it
+   (Section 8).
 
 ## 13. First milestone: Device Introspection
 


### PR DESCRIPTION
Follow-up to the merged phase-2 work (this note wasn't part of those PRs):
documents how the shim selects a normalizer by the *shape* of the data a
library returns.

- **§8** — normalization is a separate, pluggable step. Raw vendor data (the
  native IQM client, and QRMI via `target()`) is normalized through `qhw-iqm`;
  a neutral Qiskit `Target` (QDMI-on-IQM, and any future `BackendV2` vendor)
  through `backend_normalize`. This replaces the earlier per-library
  (`qhw-qdmi` / `qhw-qrmi`) sketch.
- **§12** — adds an open decision: shape-driven normalization vs a single
  `Target`-based normalizer (uniform, but gives up the provider adapter's
  calibration/quality richness).

Doc-only; captures the design discussion from the phase-2 review.