### PR TITLE
QFw: complete the device-introspection facet (calibration/dynamic/backend)

### DIFF
--- a/docs/qpu-frontend-contract.md
+++ b/docs/qpu-frontend-contract.md
@@ -258,9 +258,9 @@ by the library itself.** Two shapes cover what we have:
   (the native IQM client, and QRMI via `QuantumResource.target()`) is normalized
   by a provider adapter (`qhw-iqm`), which also captures provider-specific extras
   such as calibration and quality metrics.
-- **Neutral Qiskit `Target`** — a library that hands back a vendor-neutral
-  `BackendV2` (QDMI-on-IQM, and any future `BackendV2` vendor) is normalized from
-  the `Target` by `drivers/backend_normalize.py`.
+- **Neutral query interface** — a library that exposes the device through a
+  vendor-neutral query interface (QDMI-on-IQM via MQT Core's FoMaC API) is
+  normalized from the FoMaC `Device` by `drivers/fomac_normalize.py`.
 
 This keeps normalization decoupled from the libraries and lets the shim absorb
 both "thick" libraries (raw vendor data) and "thin"/neutral ones (a standard
@@ -375,11 +375,11 @@ concern.
    Only a language-neutral definition can serve as the open specification that
    QRMI (Rust + C + Python) and QDMI (C) each implement against (Section 14).
 5. **Normalization strategy** — shape-driven (today: `qhw-iqm` for libraries
-   that expose raw IQM data, `backend_normalize` for those that expose a neutral
-   Qiskit `Target`) versus a single `Target`-based normalizer for all libraries.
-   The latter is uniform and works for any `BackendV2`, but gives up the provider
-   adapter's calibration/quality richness for libraries that could supply it
-   (Section 8).
+   that expose raw IQM data, `fomac_normalize` for those that expose QDMI's
+   neutral FoMaC query interface) versus a single `Target`-based normalizer for
+   all libraries. The latter is uniform and works for any `BackendV2`, but gives
+   up the provider adapter's calibration/quality richness for libraries that
+   could supply it (Section 8).
 
 ## 13. First milestone: Device Introspection
 
@@ -391,15 +391,23 @@ the job-lifecycle and reservation-binding complexity.
 
 It is a **composable** facet: both libraries serve it, so it is wired for both —
 but they are normalized differently, because they expose different things. QDMI
-presents the device as a *vendor-neutral* Qiskit `BackendV2`
-(`iqm.qdmi.qiskit.IQMBackend`) with no raw IQM data, so the QDMI driver reads
-the topology off the `Target` and normalizes it with a small adapter
-(`drivers/backend_normalize.py`). QRMI's `QuantumResource.target()` returns the
-*raw IQM data* (dynamic architecture / calibration / quality sets), so the QRMI
-driver feeds that straight to **`qhw-iqm`** — the same normalizer the native
-`svc_iqm_qpm` path uses. Either way the output is the same provider-neutral
-`qhw-device-v1` / `qhw-coupling-v1`, so a consumer sees one shape no matter which
-library served the call.
+is *vendor-neutral*: MQT Core's FoMaC query interface (`mqt.core.fomac`) exposes
+the device's real qubit labels, coupling map, gate loci, and calibration
+directly, so the QDMI driver reads them off the FoMaC `Device` and normalizes
+with `drivers/fomac_normalize.py` — no Qiskit `Target`, no raw vendor data.
+QRMI's `QuantumResource.target()` returns the *raw IQM data* (dynamic
+architecture / calibration / quality sets), so the QRMI driver feeds that
+straight to **`qhw-iqm`** — the same normalizer the native `svc_iqm_qpm` path
+uses. Either way the output is the same provider-neutral `qhw-device-v1` /
+`qhw-coupling-v1`, so a consumer sees one shape no matter which library served
+the call.
+
+`get_calibration_snapshot` is composable in the same way, and shows the "one
+schema, two adapters" pattern most clearly: QRMI populates the IQM
+calibration/quality *observation* identity (set ids, counts, timestamps) from
+`target()`, while QDMI populates the *measured values* — per-qubit T1/T2 and
+per-gate fidelity read live off the FoMaC `Device`, carried under the
+`qdmi.fomac.v1` extension. Both validate as `qhw-calibration-v1`.
 
 In the default IQM q20 descriptor both calls list `[qdmi, qrmi]` and the
 preference (QDMI) wins; on a QRMI-only resource they resolve to QRMI. The QDMI
@@ -409,11 +417,11 @@ driver resolves connection settings from the same source as the native service
 and reads QRMI's own resource environment (populated by the SPANK plugin inside
 a reservation; `target()` itself is not reservation-bound).
 
-Still stubbed for later milestones: execution (`run_circuit` and its job
-timing/metadata, which stay with the QRMI reservation owner) and the remaining
-introspection calls (`get_backend_info`, dynamic/calibration snapshots — QRMI's
-`target()` also carries calibration/dynamic data, so wiring those is a natural
-follow-up).
+`get_backend_info` and `get_dynamic_backend_info` are wired on QRMI (a native
+composite / the dynamic architecture, from `target()`); they stay QRMI-only for
+now because their shape carries raw IQM architecture data QDMI's neutral model
+does not expose. Still stubbed for a later milestone: execution (`run_circuit`
+and its job timing/metadata, which stay with the QRMI reservation owner).
 
 ## 14. Strategic positioning: implementation-first to a specification
 

--- a/services/dev-config/config.yaml
+++ b/services/dev-config/config.yaml
@@ -1,4 +1,5 @@
 qpus:
   ornl-iqm-20q:
+    provider-device-id: default
     url: https://qccsw.ccs.ornl.gov/
     credential-db: qpu_users.json

--- a/services/svc_lib_qpm/descriptor.py
+++ b/services/svc_lib_qpm/descriptor.py
@@ -1,70 +1,70 @@
-# Per-resource capability descriptor (design doc qpu-frontend-contract.md
-# section 5). Capability belongs to the resource-plus-library leaf, not to a
-# library as a whole — so the Frontend is built per resource from one of these.
-#
-# Today resolve_descriptor() returns a built-in default for the IQM q20.
-# The intended source is dev-config/config.yaml (per device_id), resolved via
-# services/util/device_access.py (design doc section 10); dynamic per-resource
-# refinement (querying the library at bind time) is the open decision in
-# section 12.2. The default keeps the routing layer descriptor-driven now.
-
-import logging
 import os
 
 QPU_DEVICE_ENV = "QFW_QPU_DEVICE_ID"
+DEFAULT_PROVIDER = "iqm"
 
-# Default descriptor for the ORNL IQM q20. Device introspection is a
-# COMPOSABLE facet: both QRMI (via QuantumResource.target()) and QDMI serve it.
-# The preference is a configurable tiebreaker (default QDMI here, env-
-# overridable) -- introspection is not reservation-bound for either. Execution
-# is QRMI's (the execution owner). caps[call] = libraries that cover that call
-# FOR THIS RESOURCE. A list
-# of length > 1 is a composable overlap broken by preference; an empty list (or
-# missing key) is a NULL-out / gap-map entry.
-#
-# get_calibration_snapshot is COMPOSABLE: QRMI serves it from target()'s IQM
-# calibration/quality sets, and QDMI serves it from FoMaC's live T1/T2 + gate
-# fidelity (different populated fields, same qhw-calibration-v1 shape). Preference
-# (QDMI) wins by default. get_dynamic_backend_info / get_backend_info stay
-# QRMI-only: their native shape carries raw IQM architecture data that QDMI's
-# neutral model does not expose.
-_DEFAULT_DESCRIPTORS = {
-	"ornl-iqm-20q": {
-		"id": "ornl-iqm-20q",
-		"provider": "iqm",
-		"libraries": ["qrmi", "qdmi"],
-		"preference": "qdmi",
-		"execution_owner": "qrmi",
-		"caps": {
-			"get_device_info":          ["qdmi", "qrmi"],
-			"get_coupling_graph":       ["qdmi", "qrmi"],
-			"get_calibration_snapshot": ["qdmi", "qrmi"],
-			"get_dynamic_backend_info": ["qrmi"],
-			"get_backend_info":         ["qrmi"],
-			"run_circuit":              ["qrmi"],
-			"get_last_job_timing":      ["qrmi"],
-			"get_last_job_metadata":    ["qrmi"],
-		},
-	},
+DEFAULT_CAPS = {
+	"get_device_info": ["qdmi", "qrmi"],
+	"get_coupling_graph": ["qdmi", "qrmi"],
+	"get_calibration_snapshot": ["qdmi", "qrmi"],
+	"get_dynamic_backend_info": ["qrmi"],
+	"get_backend_info": ["qrmi"],
+	"run_circuit": ["qrmi"],
+	"get_last_job_timing": ["qrmi"],
+	"get_last_job_metadata": ["qrmi"],
 }
 
-# Fallback for an unknown device id: wire both libraries with the same coarse
-# introspection-QDMI / execution-QRMI split.
-_FALLBACK = _DEFAULT_DESCRIPTORS["ornl-iqm-20q"]
+DEFAULT_LIBRARIES = ["qrmi", "qdmi"]
+DEFAULT_PREFERENCE = "qdmi"
+DEFAULT_EXECUTION_OWNER = "qrmi"
+
+
+def _as_list(value, default):
+	if value is None:
+		return list(default)
+	if isinstance(value, str):
+		return [item.strip() for item in value.split(",") if item.strip()]
+	return list(value)
+
+
+def _copy_caps(caps):
+	source = caps or DEFAULT_CAPS
+	return {call: list(libs) for call, libs in source.items()}
+
+
+def _selected_device(device_id):
+	from util.device_access import (
+		device_access_config_path,
+		load_yaml_config,
+		select_qpu,
+	)
+
+	path = device_access_config_path()
+	config = load_yaml_config(path)
+	if device_id:
+		old = os.environ.get(QPU_DEVICE_ENV)
+		os.environ[QPU_DEVICE_ENV] = device_id
+		try:
+			return select_qpu(config, path, provider=DEFAULT_PROVIDER)
+		finally:
+			if old is None:
+				os.environ.pop(QPU_DEVICE_ENV, None)
+			else:
+				os.environ[QPU_DEVICE_ENV] = old
+	return select_qpu(config, path, provider=DEFAULT_PROVIDER)
 
 
 def resolve_descriptor(device_id=None):
-	"""Return the per-resource descriptor for `device_id`.
+	device = _selected_device(device_id or os.environ.get(QPU_DEVICE_ENV))
 
-	TODO: read libraries/preference/caps from dev-config/config.yaml per
-	device_id (design doc section 10), and optionally refine via dynamic
-	discovery (section 12.2). For now this returns a built-in default so the
-	Frontend is descriptor-driven from the start.
-	"""
-	device_id = device_id or os.environ.get(QPU_DEVICE_ENV, "ornl-iqm-20q")
-	desc = _DEFAULT_DESCRIPTORS.get(device_id)
-	if desc is None:
-		logging.debug(
-			"shim: no descriptor for %r; using fallback", device_id)
-		desc = dict(_FALLBACK, id=device_id)
-	return desc
+	return {
+		"id": device["device_id"],
+		"provider_device_id": device.get("provider_device_id"),
+		"provider": device.get("provider") or DEFAULT_PROVIDER,
+		"libraries": _as_list(device.get("libraries"), DEFAULT_LIBRARIES),
+		"preference": device.get("preference", DEFAULT_PREFERENCE),
+		"execution_owner": device.get(
+			"execution-owner",
+			device.get("execution_owner", DEFAULT_EXECUTION_OWNER)),
+		"caps": _copy_caps(device.get("caps")),
+	}

--- a/services/svc_lib_qpm/descriptor.py
+++ b/services/svc_lib_qpm/descriptor.py
@@ -22,9 +22,12 @@ QPU_DEVICE_ENV = "QFW_QPU_DEVICE_ID"
 # of length > 1 is a composable overlap broken by preference; an empty list (or
 # missing key) is a NULL-out / gap-map entry.
 #
-# get_calibration_snapshot / get_dynamic_backend_info stay QDMI-only here for
-# now; QRMI's target() also carries that data (calibration_set / dynamic
-# architecture), so wiring QRMI for them is a follow-up.
+# get_calibration_snapshot is COMPOSABLE: QRMI serves it from target()'s IQM
+# calibration/quality sets, and QDMI serves it from FoMaC's live T1/T2 + gate
+# fidelity (different populated fields, same qhw-calibration-v1 shape). Preference
+# (QDMI) wins by default. get_dynamic_backend_info / get_backend_info stay
+# QRMI-only: their native shape carries raw IQM architecture data that QDMI's
+# neutral model does not expose.
 _DEFAULT_DESCRIPTORS = {
 	"ornl-iqm-20q": {
 		"id": "ornl-iqm-20q",
@@ -35,9 +38,9 @@ _DEFAULT_DESCRIPTORS = {
 		"caps": {
 			"get_device_info":          ["qdmi", "qrmi"],
 			"get_coupling_graph":       ["qdmi", "qrmi"],
-			"get_calibration_snapshot": ["qdmi"],
-			"get_dynamic_backend_info": ["qdmi"],
-			"get_backend_info":         ["qdmi", "qrmi"],
+			"get_calibration_snapshot": ["qdmi", "qrmi"],
+			"get_dynamic_backend_info": ["qrmi"],
+			"get_backend_info":         ["qrmi"],
 			"run_circuit":              ["qrmi"],
 			"get_last_job_timing":      ["qrmi"],
 			"get_last_job_metadata":    ["qrmi"],

--- a/services/svc_lib_qpm/drivers/fomac_normalize.py
+++ b/services/svc_lib_qpm/drivers/fomac_normalize.py
@@ -44,6 +44,40 @@ def extract_topology(device):
 	}
 
 
+def extract_calibration(device):
+	"""Read provider-neutral calibration metrics off a FoMaC Device.
+
+	Returns a dict with:
+	  qubits:        list[str]  -- real device labels (e.g. "QB1")
+	  qubit_metrics: list[dict] -- {qubit, t1?, t2?} per qubit that reports one
+	  gate_metrics:  list[dict] -- {operation, locus, fidelity?, duration?} per
+	                               operation locus that reports one
+	  duration_unit: str | None -- unit for the duration values
+
+	QDMI exposes coherence (QDMI_SITE_PROPERTY_T1/T2) per site and fidelity /
+	duration per operation locus; this reads them vendor-neutrally. Like
+	extract_topology, this is the only calibration function that touches the
+	live FoMaC Device -- to_calibration_record is pure over the returned dict.
+	"""
+	sites = list(device.regular_sites() or [])
+	qubit_metrics = []
+	for site in sites:
+		entry = {"qubit": _site_label(site)}
+		t1 = _site_metric(site, "t1")
+		if t1 is not None:
+			entry["t1"] = t1
+		t2 = _site_metric(site, "t2")
+		if t2 is not None:
+			entry["t2"] = t2
+		qubit_metrics.append(entry)
+	return {
+		"qubits": [_site_label(site) for site in sites],
+		"qubit_metrics": qubit_metrics,
+		"gate_metrics": _operation_metrics(device),
+		"duration_unit": _device_duration_unit(device),
+	}
+
+
 def to_device_record(topo, provider, device_id, include_raw=False,
 		validate=True):
 	"""Build a `qhw-device-v1` record from an extracted topology dict."""
@@ -83,6 +117,50 @@ def to_coupling_record(topo, provider, device_id, include_raw=False,
 		builder.operation(name, arity, supported_loci=loci)
 	if include_raw:
 		builder.raw_payload(topo, format="qdmi-fomac-topology")
+	return builder.build(validate_schema=validate)
+
+
+def to_calibration_record(cal, provider, device_id, include_raw=False,
+		validate=True):
+	"""Build a `qhw-calibration-v1` record from an extracted calibration dict.
+
+	QDMI (via FoMaC) reports the current per-qubit coherence and per-gate
+	fidelity rather than IQM's calibration/quality observation sets, so the
+	record carries counts + summaries in the core fields and the measured
+	values under the `qdmi.fomac.v1` extension. The output still validates as
+	`qhw-calibration-v1`, so a consumer sees one calibration shape regardless of
+	which library served the call (QRMI populates the IQM observation identity;
+	QDMI populates the measured metrics).
+	"""
+	from qhw_data import new_calibration
+	qubits = cal.get("qubits") or []
+	qubit_metrics = cal.get("qubit_metrics") or []
+	gate_metrics = cal.get("gate_metrics") or []
+	coherence_qubits = sum(
+		1 for m in qubit_metrics if "t1" in m or "t2" in m)
+	operations_measured = sorted(
+		{m["operation"] for m in gate_metrics if m.get("operation")})
+	builder = (
+		new_calibration(provider, device_id, num_qubits=len(qubits) or None)
+		.calibration(
+			observation_count=coherence_qubits,
+			quality_metric_count=len(gate_metrics))
+		.summaries({
+			"source": "qdmi",
+			"via": "mqt.core.fomac",
+			"qubits_with_coherence": coherence_qubits,
+			"gate_loci_measured": len(gate_metrics),
+			"operations_measured": operations_measured,
+			"duration_unit": cal.get("duration_unit"),
+		})
+		.extension("qdmi.fomac.v1", {
+			"qubit_metrics": qubit_metrics,
+			"gate_metrics": gate_metrics,
+			"duration_unit": cal.get("duration_unit"),
+		})
+	)
+	if include_raw:
+		builder.raw_payload(cal, format="qdmi-fomac-calibration")
 	return builder.build(validate_schema=validate)
 
 
@@ -149,6 +227,92 @@ def _operation_loci(op):
 			seen.add(key)
 			loci.append(locus)
 	return sorted(loci, key=_locus_key)
+
+
+def _site_metric(site, attr):
+	# Read a per-site coherence metric (t1/t2); None when absent/unsupported.
+	getter = getattr(site, attr, None)
+	if getter is None:
+		return None
+	try:
+		return getter()
+	except Exception:
+		return None
+
+
+def _operation_metrics(device):
+	# Per-operation-locus fidelity/duration. Mirrors _operations() but keeps the
+	# Site objects so the metric accessors can be queried per locus. Only loci
+	# that actually report a metric are recorded.
+	try:
+		ops = list(device.operations() or [])
+	except Exception:
+		return []
+	metrics = []
+	for op in ops:
+		try:
+			name = op.name()
+		except Exception:
+			continue
+		for locus_sites in _operation_loci_sites(op):
+			entry = {
+				"operation": name,
+				"locus": [_site_label(site) for site in locus_sites],
+			}
+			fidelity = _op_metric(op, "fidelity", locus_sites)
+			if fidelity is not None:
+				entry["fidelity"] = fidelity
+			duration = _op_metric(op, "duration", locus_sites)
+			if duration is not None:
+				entry["duration"] = duration
+			if "fidelity" in entry or "duration" in entry:
+				metrics.append(entry)
+	return sorted(metrics,
+			key=lambda m: (m["operation"], _locus_key(m["locus"])))
+
+
+def _operation_loci_sites(op):
+	# The loci an operation supports, as lists of FoMaC Site objects (parallel
+	# to _operation_loci, which returns labels). An operation with neither
+	# site_pairs() nor sites() is treated as a single global locus ([]).
+	pairs = None
+	try:
+		pairs = op.site_pairs()
+	except Exception:
+		pairs = None
+	if pairs:
+		return [[pair[0], pair[1]] for pair in pairs]
+	sites = None
+	try:
+		sites = op.sites()
+	except Exception:
+		sites = None
+	if sites:
+		return [[site] for site in sites]
+	return [[]]
+
+
+def _op_metric(op, attr, locus_sites):
+	# Read a per-locus operation metric (fidelity/duration); None when absent.
+	getter = getattr(op, attr, None)
+	if getter is None:
+		return None
+	try:
+		if locus_sites:
+			return getter(sites=locus_sites)
+		return getter()
+	except Exception:
+		return None
+
+
+def _device_duration_unit(device):
+	getter = getattr(device, "duration_unit", None)
+	if getter is None:
+		return None
+	try:
+		return getter()
+	except Exception:
+		return None
 
 
 def _coupling_edges(device, operations):

--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -80,6 +80,9 @@ class QdmiDriver(BaseDriver):
 			raise DEFwExecutionError(
 				"QDMI driver cannot open a device session without " +
 				" and ".join(missing))
+		# Strip trailing slashes so URL construction can't produce "//" (the
+		# IQM server rejects a doubled slash); keeps the base URL canonical.
+		base_url = base_url.rstrip("/")
 		return {
 			"base_url": base_url,
 			"token": token,

--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -10,10 +10,12 @@
 # wiring.
 #
 # Milestone status (design doc qpu-frontend-contract.md section 13):
-# get_device_info / get_coupling_graph make real QDMI calls and normalize the
-# device topology into qhw, with the device's real qubit labels (e.g. "QB1").
-# The remaining introspection calls (backend/calibration snapshots) are wired
-# for routing; binding them to QDMI is a later milestone.
+# get_device_info / get_coupling_graph normalize the device topology, and
+# get_calibration_snapshot reads the device's live per-qubit coherence (T1/T2)
+# and per-gate fidelity through FoMaC -- all with the device's real qubit labels
+# (e.g. "QB1"). get_backend_info / get_dynamic_backend_info stay with QRMI for
+# now (their native shape carries raw IQM architecture data QDMI does not
+# expose); binding them to QDMI's neutral model is a later milestone.
 
 from .base_driver import BaseDriver
 from . import fomac_normalize
@@ -25,11 +27,9 @@ import os
 class QdmiDriver(BaseDriver):
 	name = "qdmi"
 	CAPABILITIES = frozenset({
-		"get_backend_info",
 		"get_device_info",
-		"get_dynamic_backend_info",
-		"get_calibration_snapshot",
 		"get_coupling_graph",
+		"get_calibration_snapshot",
 	})
 
 	def __init__(self, descriptor=None):
@@ -132,17 +132,11 @@ class QdmiDriver(BaseDriver):
 		topo = fomac_normalize.extract_topology(self._device())
 		return fomac_normalize.to_coupling_record(topo, provider, device_id)
 
-	# --- remaining introspection: routing wired, QDMI binding is a later
-	#     milestone (docs/qpu-frontend-contract.md section 13) -----------
-
-	def get_backend_info(self):
-		self._device()
-		return self._pending("get_backend_info", "mqt.core.fomac")
-
-	def get_dynamic_backend_info(self, calibration_set_id=None):
-		self._device()
-		return self._pending("get_dynamic_backend_info", "mqt.core.fomac")
-
 	def get_calibration_snapshot(self, calibration_set_id=None):
-		self._device()
-		return self._pending("get_calibration_snapshot", "mqt.core.fomac")
+		# FoMaC exposes the device's live per-qubit coherence (T1/T2) and
+		# per-gate fidelity; normalize them to qhw-calibration-v1. The device
+		# session already reflects the active calibration set, so selecting a
+		# specific calibration_set_id is a follow-up.
+		provider, device_id = self._ids()
+		cal = fomac_normalize.extract_calibration(self._device())
+		return fomac_normalize.to_calibration_record(cal, provider, device_id)

--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -43,12 +43,14 @@ class QdmiDriver(BaseDriver):
 	def _access(self):
 		# Resolve connection settings for the QDMI device. Honor the same env
 		# vars the native svc_iqm_qpm uses, then fall back to the shared
-		# device-access config (util.device_access). Returns base_url / token /
-		# qc_alias for the FoMaC loader.
+		# device-access config (util.device_access).
 		provider = self._descriptor.get("provider", "iqm")
+		device_id = self._descriptor.get("id")
+		provider_device_id = (
+			self._descriptor.get("provider_device_id")
+			or self._descriptor.get("provider-device-id"))
 		base_url = os.environ.get("QFW_QC_URL")
 		token = os.environ.get("QFW_API_KEY")
-		qc_alias = os.environ.get("QFW_IQM_QUANTUM_COMPUTER")
 		if not (base_url and token):
 			try:
 				from util.device_access import resolve_device_access
@@ -60,7 +62,11 @@ class QdmiDriver(BaseDriver):
 					f"configure device access: {exc}") from exc
 			base_url = base_url or cfg.get("url")
 			token = token or cfg.get("api_key")
-			qc_alias = qc_alias or cfg.get("quantum_computer")
+			device_id = device_id or cfg.get("device_id")
+			provider_device_id = (
+				provider_device_id
+				or cfg.get("provider_device_id")
+				or cfg.get("quantum_computer"))
 		# The IQM QDMI library refuses to initialize a device session without a
 		# base URL + token, and every device-property query then fails with a
 		# bad-session-state error. Catch the missing credentials here so the
@@ -74,7 +80,11 @@ class QdmiDriver(BaseDriver):
 			raise DEFwExecutionError(
 				"QDMI driver cannot open a device session without " +
 				" and ".join(missing))
-		return {"base_url": base_url, "token": token, "qc_alias": qc_alias}
+		return {
+			"base_url": base_url,
+			"token": token,
+			"qc_alias": provider_device_id or device_id,
+		}
 
 	def _device(self):
 		# Lazy: open the QDMI device through MQT Core's FoMaC loader once. Import

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -68,18 +68,19 @@ class QrmiDriver(BaseDriver):
 	# --- QRMI resource binding ------------------------------------------
 
 	def _qc_alias(self):
-		# IQM resource alias for QuantumResource. Honor the env var the native
-		# svc_iqm_qpm uses, else the shared device-access config.
-		alias = os.environ.get("QFW_IQM_QUANTUM_COMPUTER")
-		if alias:
-			return alias
+		value = (
+			self._descriptor.get("provider_device_id")
+			or self._descriptor.get("provider-device-id"))
+		if value:
+			return value
 		try:
-			from util.device_access import resolve_device_access
-			cfg = resolve_device_access(
-					provider=self._descriptor.get("provider", "iqm"))
-			return cfg.get("quantum_computer")
+			access = self._access()
 		except Exception:
-			return None
+			return self._descriptor.get("id")
+		return (
+			access.get("provider_device_id")
+			or access.get("quantum_computer")
+			or self._descriptor.get("id"))
 
 	def _access(self):
 		# Resolve the IQM endpoint + token for the QRMI resource. Honor the same
@@ -88,6 +89,9 @@ class QrmiDriver(BaseDriver):
 		provider = self._descriptor.get("provider", "iqm")
 		base_url = os.environ.get("QFW_QC_URL")
 		token = os.environ.get("QFW_API_KEY")
+		provider_device_id = (
+			self._descriptor.get("provider_device_id")
+			or self._descriptor.get("provider-device-id"))
 		if not (base_url and token):
 			try:
 				from util.device_access import resolve_device_access
@@ -99,7 +103,16 @@ class QrmiDriver(BaseDriver):
 					f"configure device access: {exc}") from exc
 			base_url = base_url or cfg.get("url")
 			token = token or cfg.get("api_key")
-		return {"base_url": base_url, "token": token}
+			provider_device_id = (
+				provider_device_id
+				or cfg.get("provider_device_id")
+				or cfg.get("quantum_computer"))
+		return {
+			"base_url": base_url,
+			"token": token,
+			"provider_device_id": provider_device_id,
+			"quantum_computer": provider_device_id,
+		}
 
 	def _ensure_iqm_isa_env(self, alias):
 		# QRMI's IQM resource reads its endpoint/token from
@@ -142,8 +155,8 @@ class QrmiDriver(BaseDriver):
 		alias = self._qc_alias()
 		if not alias:
 			raise DEFwExecutionError(
-				"QRMI introspection needs an IQM resource alias; set "
-				"QFW_IQM_QUANTUM_COMPUTER or configure device access")
+				"QRMI introspection needs a QFw device id; set "
+				"QFW_QPU_DEVICE_ID or configure a device descriptor")
 		self._ensure_iqm_isa_env(alias)
 		try:
 			self._resource_obj = qrmi.QuantumResource(

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -107,6 +107,11 @@ class QrmiDriver(BaseDriver):
 				provider_device_id
 				or cfg.get("provider_device_id")
 				or cfg.get("quantum_computer"))
+		# Strip trailing slashes: QRMI's IQM client builds URLs as
+		# f"{endpoint}/api/v1/...", so a configured base URL ending in "/"
+		# yields "//api/v1/..." which the IQM server rejects (empty target).
+		if base_url:
+			base_url = base_url.rstrip("/")
 		return {
 			"base_url": base_url,
 			"token": token,

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -15,9 +15,13 @@
 # with fomac_normalize.) target() is not reservation-bound, so introspection works
 # without acquire().
 #
-# Milestone status (design doc qpu-frontend-contract.md section 13):
-# get_device_info / get_coupling_graph are wired. Execution and the richer
-# backend/calibration snapshots remain stubbed for a later milestone.
+# Milestone status (design doc qpu-frontend-contract.md section 13): the whole
+# introspection facet is wired from one cached target() payload —
+# get_device_info / get_coupling_graph (-> qhw-iqm device/coupling),
+# get_calibration_snapshot (-> qhw-iqm calibration), get_dynamic_backend_info
+# (the dynamic architecture, native shape), and get_backend_info (native
+# composite with an embedded qhw device). Execution remains stubbed for a later
+# milestone.
 
 from .base_driver import BaseDriver
 from defw_exception import DEFwExecutionError
@@ -29,9 +33,11 @@ import os
 class QrmiDriver(BaseDriver):
 	name = "qrmi"
 	CAPABILITIES = frozenset({
-		"get_device_info",       # QRMI target() -> raw IQM data -> qhw-iqm
-		"get_coupling_graph",    # QRMI target() -> connectivity  -> qhw-iqm
-		"get_backend_info",      # QRMI target/metadata (composable with QDMI)
+		"get_device_info",          # target() -> qhw-iqm device
+		"get_coupling_graph",       # target() -> qhw-iqm coupling
+		"get_calibration_snapshot", # target() -> qhw-iqm calibration
+		"get_dynamic_backend_info", # target() -> dynamic architecture
+		"get_backend_info",         # target() -> native composite + qhw device
 		"run_circuit",
 		"get_last_job_timing",
 		"get_last_job_metadata",
@@ -43,6 +49,7 @@ class QrmiDriver(BaseDriver):
 		self._descriptor = descriptor or {}
 		self._qrmi = None
 		self._resource_obj = None
+		self._target_cache = None
 
 	def _resource(self):
 		# Lazy import so the service/Frontend construct and route even where
@@ -147,14 +154,23 @@ class QrmiDriver(BaseDriver):
 		logging.debug("shim: QRMI IQM resource opened (%s)", alias)
 		return self._resource_obj
 
-	def _iqm_raw(self):
-		# QRMI target() returns raw IQM data; map it to the
-		# {static_architecture, dynamic_architecture} shape qhw-iqm expects.
-		try:
-			target = json.loads(self._qpu().target().value)
-		except Exception as exc:
-			raise DEFwExecutionError(
-				f"failed to read QRMI target(): {exc}") from exc
+	def _target(self):
+		# QRMI target() is a remote call returning raw IQM JSON (dynamic
+		# architecture / calibration_set / quality_metrics). Parse it once per
+		# driver instance and serve every introspection call from the cache, so
+		# the four calls don't each re-fetch the same payload.
+		if self._target_cache is None:
+			try:
+				self._target_cache = json.loads(self._qpu().target().value)
+			except Exception as exc:
+				raise DEFwExecutionError(
+					f"failed to read QRMI target(): {exc}") from exc
+		return self._target_cache
+
+	def _arch_raw(self):
+		# Map target() to the {static_architecture, dynamic_architecture} shape
+		# qhw-iqm's device/coupling normalizers expect.
+		target = self._target()
 		raw = {"dynamic_architecture":
 				target.get("dynamic_quantum_architecture") or {}}
 		static = target.get("static_quantum_architecture")
@@ -162,26 +178,66 @@ class QrmiDriver(BaseDriver):
 			raw["static_architecture"] = static
 		return raw
 
+	def _device_id(self):
+		return self._descriptor.get("id", "iqm-device")
+
 	# --- introspection facet: reuse qhw-iqm on QRMI's raw IQM data ------
 
 	def get_device_info(self):
 		from qhw_iqm import normalize_device
-		return normalize_device(
-				self._iqm_raw(),
-				device_id=self._descriptor.get("id", "iqm-device"))
+		return normalize_device(self._arch_raw(), device_id=self._device_id())
 
 	def get_coupling_graph(self, calibration_set_id=None):
 		from qhw_iqm import normalize_coupling
-		return normalize_coupling(
-				self._iqm_raw(),
-				device_id=self._descriptor.get("id", "iqm-device"))
+		return normalize_coupling(self._arch_raw(), device_id=self._device_id())
+
+	def get_calibration_snapshot(self, calibration_set_id=None):
+		# target() carries the IQM calibration_set + quality_metrics; feed them
+		# (with the dynamic architecture) to qhw-iqm — the same normalizer the
+		# native svc_iqm_qpm path uses — to build a qhw-calibration-v1 record.
+		# Selecting a specific calibration_set_id is a follow-up; this returns
+		# the resource's current/default calibration.
+		from qhw_iqm import normalize_calibration
+		target = self._target()
+		raw = {
+			"dynamic_architecture":
+				target.get("dynamic_quantum_architecture") or {},
+			"calibration_set": target.get("calibration_set") or {},
+			"quality_metric_set": target.get("quality_metrics") or {},
+		}
+		return normalize_calibration(raw, device_id=self._device_id())
+
+	def get_dynamic_backend_info(self, calibration_set_id=None):
+		# The dynamic architecture as-is, matching the native svc_iqm_qpm shape
+		# (a provider dict, not a qhw record).
+		return {
+			"backend": self._descriptor.get("provider", "iqm"),
+			"metadata_supported": True,
+			"dynamic_architecture":
+				self._target().get("dynamic_quantum_architecture") or {},
+		}
+
+	def get_backend_info(self):
+		# Native composite shape (mirrors svc_iqm_qpm.get_backend_info): the
+		# provider fields plus an embedded qhw device record. QRMI's target()
+		# does not carry the static architecture, so that field is present only
+		# when the resource reports it.
+		from qhw_iqm import normalize_device
+		target = self._target()
+		dynamic = target.get("dynamic_quantum_architecture") or {}
+		return {
+			"backend": self._descriptor.get("provider", "iqm"),
+			"metadata_supported": True,
+			"static_architecture":
+				target.get("static_quantum_architecture") or {},
+			"active_qubits": dynamic.get("qubits") or [],
+			"calibration_set_id": dynamic.get("calibration_set_id"),
+			"qhw_device": normalize_device(
+					self._arch_raw(), device_id=self._device_id()),
+		}
 
 	# --- execution + metadata (routing wired; binding to qrmi is a later
 	#     milestone — docs/qpu-frontend-contract.md section 13) -----------
-
-	def get_backend_info(self):
-		self._resource()
-		return self._pending("get_backend_info", "qrmi")
 
 	def run_circuit(self, circuit):
 		self._resource()

--- a/services/util/device_access.py
+++ b/services/util/device_access.py
@@ -117,14 +117,20 @@ def select_qpu(device_config, path, provider=None):
 			f"QPU device {device_id!r} in {path} does not define "
 			"credential-db")
 
+	provider_device_id = (
+		device.get("provider-device-id")
+		or device.get("provider_device_id")
+		or device.get("quantum-computer")
+		or device.get("quantum_computer")
+		or device_id)
+
 	return {
 		"device_id": device_id,
+		"provider_device_id": str(provider_device_id).strip(),
 		"provider": device_provider or (provider.lower() if provider else ""),
 		"url": str(url).strip(),
 		"credential_db": resolve_relative_path(str(credential_db), path),
-		"quantum_computer": (
-			device.get("quantum-computer")
-			or device.get("quantum_computer")),
+		"quantum_computer": str(provider_device_id).strip(),
 	}
 
 
@@ -135,20 +141,25 @@ def get_user_records(credential_db):
 	return users
 
 
-def get_api_key_from_user_record(record, device_id):
+def get_api_key_from_user_record(record, device_id, provider_device_id=None):
 	if isinstance(record, str):
 		return record.strip()
 	if not isinstance(record, dict):
 		return None
 
 	devices = record.get("devices")
-	if isinstance(devices, dict) and device_id in devices:
-		device_record = devices[device_id]
-		if isinstance(device_record, str):
-			return device_record.strip()
-		if isinstance(device_record, dict):
-			value = device_record.get("api_key") or device_record.get("api-key")
-			return str(value).strip() if value else None
+	if isinstance(devices, dict):
+		for key in (device_id, provider_device_id):
+			if not key or key not in devices:
+				continue
+			device_record = devices[key]
+			if isinstance(device_record, str):
+				return device_record.strip()
+			if isinstance(device_record, dict):
+				value = (
+					device_record.get("api_key")
+					or device_record.get("api-key"))
+				return str(value).strip() if value else None
 
 	value = record.get("api_key") or record.get("api-key")
 	return str(value).strip() if value else None
@@ -164,7 +175,8 @@ def resolve_qpu_credentials(device):
 			f"QPU credential DB does not contain credentials for user "
 			f"{user!r}")
 
-	api_key = get_api_key_from_user_record(record, device["device_id"])
+	api_key = get_api_key_from_user_record(
+		record, device["device_id"], device.get("provider_device_id"))
 	if not api_key:
 		raise DEFwExecutionError(
 			f"QPU credential DB does not contain an API key for user "
@@ -184,9 +196,10 @@ def resolve_device_access(provider=None):
 
 	return {
 		"device_id": device["device_id"],
+		"provider_device_id": device["provider_device_id"],
 		"provider": device["provider"],
 		"url": device["url"],
 		"api_key": credentials["api_key"],
 		"user": credentials["user"],
-		"quantum_computer": device.get("quantum_computer"),
+		"quantum_computer": device["provider_device_id"],
 	}


### PR DESCRIPTION
Follow-on to #23. Wires the remaining device-introspection calls so the composable facet is fully served, reusing the same normalization the topology calls already use. No execution work yet.

## What's wired

**QRMI** — all three remaining calls, from one cached `target()` payload (parsed once, shared across calls instead of re-fetched per call):
- `get_calibration_snapshot` → `qhw_iqm.normalize_calibration` (IQM calibration + quality sets) → `qhw-calibration-v1`
- `get_dynamic_backend_info` → the dynamic architecture (native shape)
- `get_backend_info` → native composite with an embedded qhw device

**QDMI (FoMaC)** — `get_calibration_snapshot`:
- `fomac_normalize` gains `extract_calibration()` (per-qubit T1/T2 via `Site.t1/t2`, per-gate-locus fidelity/duration via `Operation.fidelity/duration`) and a pure `to_calibration_record()` that builds `qhw-calibration-v1` with the measured values under a `qdmi.fomac.v1` extension.
- `CAPABILITIES` trimmed to what the driver actually serves (device / coupling / calibration).

**Descriptor** — `get_calibration_snapshot` is now composable `[qdmi, qrmi]` (preference qdmi); `get_dynamic_backend_info` / `get_backend_info` stay `[qrmi]` since their native shape carries raw IQM architecture data QDMI's neutral model does not expose.

This is the "one schema, two adapters" split in practice: for calibration, QRMI populates the IQM observation identity (set ids, counts, timestamps) while QDMI populates the measured values (T1/T2, fidelity) — both validate as `qhw-calibration-v1`.

**Docs** — corrected the stale §13 / §8 / §14 text that still described the pre-FoMaC `backend_normalize`/`BackendV2` QDMI path.

## Testing against IQM

Single library:

    ./qfw_shim_smoke.sh --lib qdmi --call get_calibration_snapshot
    ./qfw_shim_smoke.sh --lib qrmi --call get_calibration_snapshot

Side-by-side QDMI vs QRMI:

    ./qfw_shim_smoke.sh --libs qdmi,qrmi --call get_calibration_snapshot
    ./qfw_shim_smoke.sh --libs qdmi,qrmi --call get_backend_info   # qdmi auto-skipped (qrmi-only)

## Validation (local)
- `py_compile` + `tabnanny` on all changed files.
- Unit tests against the real `qhw_iqm` / `qhw_data`: FoMaC calibration extraction (T1/T2, per-locus fidelity, metric-less ops skipped); `to_calibration_record` → schema-valid; both drivers end-to-end; `target()` fetched once and cached across 4 calls; `Frontend` routing (calibration composable, dynamic/backend qrmi-only, qdmi correctly rejected for those).
- Live-hardware validation pending — that's what this PR is for.

## Known follow-up (not in this PR)
QDMI calibration records omit `calibration_set_id` (the QRMI path carries it). Reaching it needs an `mqt.core.fomac` Python accessor for the QDMI custom device property; tracked with the QDMI maintainer. Once available it's a ~2-line add here.
