### PR TITLE
QFw: wire QRMI circuit execution (OpenQASM -> IQM run_circuit)

### DIFF
--- a/docs/qpu-frontend-contract.md
+++ b/docs/qpu-frontend-contract.md
@@ -420,8 +420,19 @@ a reservation; `target()` itself is not reservation-bound).
 `get_backend_info` and `get_dynamic_backend_info` are wired on QRMI (a native
 composite / the dynamic architecture, from `target()`); they stay QRMI-only for
 now because their shape carries raw IQM architecture data QDMI's neutral model
-does not expose. Still stubbed for a later milestone: execution (`run_circuit`
-and its job timing/metadata, which stay with the QRMI reservation owner).
+does not expose.
+
+Execution is wired on QRMI as of the next milestone: `run_circuit` takes the
+canonical **OpenQASM** form, transcodes it to an IQM circuit with the shared
+`util/iqm_transcode.py` (the same transcode the native `svc_iqm_qpm` path uses),
+submits it through QRMI's task lifecycle (`Payload.IQMServer` → `task_start` →
+poll `task_status` → `task_result`), and normalizes the counts to
+`qhw-result-v1` via `qhw-iqm`. QRMI-for-IQM has no `acquire`/`release`, so this
+first cut runs without the reservation/SPANK machinery. `get_last_job_timing`
+and `get_last_job_metadata` report the cached last job. Still to come: QDMI
+execution (via FoMaC `submit_job`) as the comparison path, and the richer job
+lifecycle. The canonical-form decision (OpenQASM3 vs QIR) is recorded in the
+`openQSE/development-analysis` comparison.
 
 ## 14. Strategic positioning: implementation-first to a specification
 

--- a/services/svc_iqm_qpm/util_iqm.py
+++ b/services/svc_iqm_qpm/util_iqm.py
@@ -1,39 +1,20 @@
-from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from defw_exception import DEFwExecutionError
 from util.device_access import (
 	QPU_DEVICE_ENV, resolve_device_access, resolve_qpu_user)
+from util.iqm_transcode import (
+	active_qubits, build_iqm_circuit, to_jsonable)
 from urllib.parse import urlsplit, urlunsplit
 from uuid import UUID
 import inspect
 import logging
-import math
 import os
-import re
 import threading
 import time
 
 REQUIRED_ENV = ("QFW_QC_URL", "QFW_API_KEY")
 DEFAULT_REQUEST_TIMEOUT = 30.0
 DEFAULT_JOB_TIMEOUT = 300.0
-
-
-def to_jsonable(value):
-	if value is None or isinstance(value, (str, int, float, bool)):
-		return value
-	if isinstance(value, UUID):
-		return str(value)
-	if isinstance(value, dict):
-		return {str(k): to_jsonable(v) for k, v in value.items()}
-	if isinstance(value, (list, tuple, set, frozenset)):
-		return [to_jsonable(v) for v in value]
-	if is_dataclass(value):
-		return to_jsonable(asdict(value))
-	if hasattr(value, "model_dump"):
-		return to_jsonable(value.model_dump(mode="json"))
-	if hasattr(value, "dict"):
-		return to_jsonable(value.dict())
-	return str(value)
 
 
 def sanitize_url(url):
@@ -55,15 +36,6 @@ def load_iqm_client_module():
 			f"starting the IQM QPM service. Import error: {exc}") from exc
 
 	return IQMClient
-
-
-def load_iqm_pulse_module():
-	try:
-		from iqm.pulse import Circuit, CircuitOperation
-	except Exception as exc:
-		raise DEFwExecutionError(
-			f"failed to import iqm.pulse circuit objects: {exc}") from exc
-	return Circuit, CircuitOperation
 
 
 def normalize_qhw_iqm(kind, raw_payload, device_id=None, include_raw=False):
@@ -300,228 +272,6 @@ def normalize_status(status):
 	if hasattr(status, "value"):
 		return str(status.value)
 	return str(status)
-
-
-def active_qubits(dynamic_architecture):
-	data = to_jsonable(dynamic_architecture)
-	qubits = data.get("qubits") or []
-	if not qubits:
-		raise DEFwExecutionError(
-			"IQM dynamic architecture did not report active qubits")
-	return [str(qubit) for qubit in qubits]
-
-
-def logical_to_physical_qubits(qasm_circuit, dynamic_architecture, mapping):
-	physical = active_qubits(dynamic_architecture)
-	num_qubits = getattr(qasm_circuit, "num_qubits", 0)
-	if mapping:
-		if isinstance(mapping, dict):
-			return {
-				index: str(mapping.get(index, mapping.get(str(index))))
-				for index in range(num_qubits)
-			}
-		return {index: str(value) for index, value in enumerate(mapping)}
-
-	if num_qubits > len(physical):
-		raise DEFwExecutionError(
-			f"circuit requires {num_qubits} qubits but IQM reports "
-			f"{len(physical)} active qubits")
-	return {index: physical[index] for index in range(num_qubits)}
-
-
-def eval_angle(value):
-	allowed = {"pi": math.pi}
-	try:
-		return float(eval(value, {"__builtins__": {}}, allowed))
-	except Exception as exc:
-		raise DEFwExecutionError(
-			f"unsupported angle expression in OpenQASM: {value!r}") from exc
-
-
-def split_qasm_statements(qasm):
-	statements = []
-	for line in qasm.splitlines():
-		line = line.split("//", 1)[0].strip()
-		if not line:
-			continue
-		for part in line.split(";"):
-			part = part.strip()
-			if part:
-				statements.append(part)
-	return statements
-
-
-def load_qiskit_circuit(qasm):
-	try:
-		from qiskit import QuantumCircuit
-		try:
-			from qiskit import qasm2
-			return qasm2.loads(qasm)
-		except Exception:
-			return QuantumCircuit.from_qasm_str(qasm)
-	except Exception as exc:
-		raise DEFwExecutionError(
-			f"failed to parse OpenQASM through qiskit: {exc}") from exc
-
-
-def serialize_qiskit_to_iqm(qasm, dynamic_architecture, mapping):
-	Circuit, _ = load_iqm_pulse_module()
-	try:
-		from iqm.qiskit_iqm import qiskit_to_iqm
-	except Exception as exc:
-		raise DEFwExecutionError(
-			"iqm.qiskit_iqm is required to serialize qiskit circuits "
-			f"for IQM execution: {exc}") from exc
-
-	qiskit_circuit = load_qiskit_circuit(qasm)
-	index_to_name = logical_to_physical_qubits(
-		qiskit_circuit, dynamic_architecture, mapping)
-	try:
-		instructions = qiskit_to_iqm.serialize_instructions(
-			qiskit_circuit, index_to_name)
-	except Exception as exc:
-		raise DEFwExecutionError(
-			"IQM could not serialize the circuit. Transpile the circuit "
-			f"to IQM-supported native operations first. Error: {exc}") from exc
-
-	return Circuit(
-		name=qiskit_circuit.name or "qfw_iqm_circuit",
-		instructions=tuple(instructions),
-		metadata={"logical_to_physical": index_to_name},
-	)
-
-
-def parse_ref(ref, qregs):
-	ref = ref.strip()
-	match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\[(\d+)\]$", ref)
-	if match:
-		reg, index = match.group(1), int(match.group(2))
-		if reg not in qregs or index >= qregs[reg]:
-			raise DEFwExecutionError(f"unknown OpenQASM qubit reference {ref}")
-		return [(reg, index)]
-	if ref in qregs:
-		return [(ref, index) for index in range(qregs[ref])]
-	raise DEFwExecutionError(f"unknown OpenQASM qubit reference {ref}")
-
-
-def build_manual_iqm_circuit(qasm, dynamic_architecture, mapping):
-	Circuit, CircuitOperation = load_iqm_pulse_module()
-	statements = split_qasm_statements(qasm)
-	qregs = {}
-	cregs = {}
-	operations = []
-
-	for statement in statements:
-		if statement.startswith("OPENQASM") or statement.startswith("include"):
-			continue
-		match = re.match(r"^qreg\s+(\w+)\[(\d+)\]$", statement)
-		if match:
-			qregs[match.group(1)] = int(match.group(2))
-			continue
-		match = re.match(r"^creg\s+(\w+)\[(\d+)\]$", statement)
-		if match:
-			cregs[match.group(1)] = int(match.group(2))
-			continue
-
-	if not qregs:
-		raise DEFwExecutionError("OpenQASM input does not define a qreg")
-
-	total_qubits = sum(qregs.values())
-	physical = active_qubits(dynamic_architecture)
-	if total_qubits > len(physical):
-		raise DEFwExecutionError(
-			f"circuit requires {total_qubits} qubits but IQM reports "
-			f"{len(physical)} active qubits")
-
-	ordered = []
-	for reg, size in qregs.items():
-		for index in range(size):
-			ordered.append((reg, index))
-	if mapping:
-		if isinstance(mapping, dict):
-			qubit_map = {
-				key: str(mapping.get(f"{key[0]}[{key[1]}]",
-							 mapping.get(key[1], mapping.get(str(key[1])))))
-				for key in ordered
-			}
-		else:
-			qubit_map = {key: str(mapping[index])
-				     for index, key in enumerate(ordered)}
-	else:
-		qubit_map = {key: physical[index] for index, key in enumerate(ordered)}
-
-	for statement in statements:
-		if statement.startswith(("OPENQASM", "include", "qreg", "creg")):
-			continue
-		if statement.startswith("barrier"):
-			refs = statement[len("barrier"):].strip()
-			locus = []
-			for ref in refs.split(","):
-				locus.extend(qubit_map[key] for key in parse_ref(ref, qregs))
-			operations.append(CircuitOperation(
-				name="barrier", locus=tuple(locus), args={}))
-			continue
-		if statement.startswith("measure"):
-			match = re.match(r"^measure\s+(.+)\s+->\s+(.+)$", statement)
-			if not match:
-				raise DEFwExecutionError(
-					f"unsupported OpenQASM measurement: {statement}")
-			qrefs = parse_ref(match.group(1), qregs)
-			cref = match.group(2).strip()
-			key = "m"
-			match_cref = re.match(r"^(\w+)\[(\d+)\]$", cref)
-			if match_cref:
-				key = f"{match_cref.group(1)}{match_cref.group(2)}"
-			elif cref not in cregs:
-				raise DEFwExecutionError(
-					f"unknown OpenQASM classical reference {cref}")
-			operations.append(CircuitOperation(
-				name="measure",
-				locus=tuple(qubit_map[key] for key in qrefs),
-				args={"key": key},
-			))
-			continue
-		match = re.match(r"^(\w+)(?:\(([^)]*)\))?\s+(.+)$", statement)
-		if not match:
-			raise DEFwExecutionError(
-				f"unsupported OpenQASM statement: {statement}")
-		gate, params, refs = match.group(1), match.group(2), match.group(3)
-		refs = [ref.strip() for ref in refs.split(",")]
-		locus = tuple(qubit_map[key] for ref in refs for key in parse_ref(ref, qregs))
-		if gate == "x":
-			operations.append(CircuitOperation(
-				name="prx", locus=locus, args={"angle": math.pi,
-							       "phase": 0.0}))
-		elif gate == "rx" and params is not None:
-			operations.append(CircuitOperation(
-				name="prx", locus=locus, args={"angle": eval_angle(params),
-							       "phase": 0.0}))
-		elif gate == "ry" and params is not None:
-			operations.append(CircuitOperation(
-				name="prx", locus=locus, args={"angle": eval_angle(params),
-							       "phase": math.pi / 2}))
-		elif gate == "cz":
-			operations.append(CircuitOperation(
-				name="cz", locus=locus, args={}))
-		else:
-			raise DEFwExecutionError(
-				"IQM service can only manually translate native "
-				f"OpenQASM gates x, rx, ry, cz, barrier, measure. "
-				f"Unsupported statement: {statement}")
-
-	return Circuit(
-		name="qfw_iqm_circuit",
-		instructions=tuple(operations),
-		metadata={"logical_to_physical": to_jsonable(qubit_map)},
-	)
-
-
-def build_iqm_circuit(qasm, dynamic_architecture, mapping):
-	try:
-		return serialize_qiskit_to_iqm(qasm, dynamic_architecture, mapping)
-	except DEFwExecutionError as exc:
-		logging.debug(f"falling back to manual IQM QASM translation: {exc}")
-		return build_manual_iqm_circuit(qasm, dynamic_architecture, mapping)
 
 
 def normalize_counts(measurement_counts):

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -28,6 +28,17 @@ from defw_exception import DEFwExecutionError
 import json
 import logging
 import os
+import time
+
+
+def _status_str(status):
+	# QRMI task_status returns a TaskStatus enum; reduce it to a lowercase
+	# string regardless of whether the binding exposes .name/.value/repr.
+	for attr in ("name", "value"):
+		value = getattr(status, attr, None)
+		if value is not None:
+			return str(value).lower()
+	return str(status).lower()
 
 
 class QrmiDriver(BaseDriver):
@@ -50,6 +61,7 @@ class QrmiDriver(BaseDriver):
 		self._qrmi = None
 		self._resource_obj = None
 		self._target_cache = None
+		self._last_job = None
 
 	def _resource(self):
 		# Lazy import so the service/Frontend construct and route even where
@@ -254,17 +266,166 @@ class QrmiDriver(BaseDriver):
 					self._arch_raw(), device_id=self._device_id()),
 		}
 
-	# --- execution + metadata (routing wired; binding to qrmi is a later
-	#     milestone — docs/qpu-frontend-contract.md section 13) -----------
+	# --- execution: OpenQASM -> IQM JSON -> QRMI task lifecycle ----------
 
 	def run_circuit(self, circuit):
-		self._resource()
-		return self._pending("run_circuit", "qrmi")
+		# Canonical form is OpenQASM (circuit.info["qasm"]). Transcode it to an
+		# IQM circuit with the shared util, submit through QRMI's task lifecycle,
+		# poll to completion, and normalize the counts to qhw-result-v1 (the same
+		# normalizer the native svc_iqm_qpm path uses). QRMI-for-IQM has no
+		# acquire/release, so there is no reservation step.
+		qrmi = self._resource()
+		info = getattr(circuit, "info", None) or {}
+		cid = circuit.get_cid() if hasattr(circuit, "get_cid") else info.get("cid")
+		qasm = info.get("qasm")
+		if not qasm:
+			raise DEFwExecutionError(
+				"QRMI run_circuit requires OpenQASM in circuit info['qasm']")
+		shots = int(info.get("num_shots", info.get("shots", 1024)))
+		mapping = info.get("iqm_qubit_mapping") or info.get("qubit_mapping")
+		use_timeslot = bool(info.get("use_timeslot", False))
+		timeout = float(info.get("timeout", 300.0))
+		poll = float(info.get("poll_interval", 1.0))
+
+		target = self._target()
+		dynamic = target.get("dynamic_quantum_architecture") or {}
+		calibration_set_id = (
+			info.get("calibration_set_id")
+			or info.get("iqm_calibration_set_id")
+			or dynamic.get("calibration_set_id"))
+
+		from util.iqm_transcode import build_iqm_circuit
+		iqm_circuit = build_iqm_circuit(qasm, dynamic, mapping)
+		iqmjson, run_request = self._build_iqmjson(
+				iqm_circuit, shots, calibration_set_id)
+
+		payload = qrmi.Payload.IQMServer(
+			iqmjson=iqmjson, job_type="circuit",
+			use_timeslot=use_timeslot, tag=None)
+
+		timing = {}
+		start = time.monotonic()
+		try:
+			job_id = self._qpu().task_start(payload)
+		except Exception as exc:
+			raise DEFwExecutionError(
+				f"QRMI task_start failed: {exc}") from exc
+		timing["submit_seconds"] = time.monotonic() - start
+
+		status = self._poll_task(job_id, timeout, poll)
+		timing["wait_seconds"] = (
+			time.monotonic() - start - timing["submit_seconds"])
+		if status != "completed":
+			self._last_job = {
+				"id": str(job_id), "status": status, "cid": cid,
+				"timing": timing, "shots": shots}
+			raise DEFwExecutionError(
+				f"QRMI job {job_id} finished with status {status!r}")
+
+		result_started = time.monotonic()
+		try:
+			result_json = json.loads(self._qpu().task_result(job_id).value)
+		except Exception as exc:
+			raise DEFwExecutionError(
+				f"QRMI task_result failed: {exc}") from exc
+		timing["result_fetch_seconds"] = time.monotonic() - result_started
+		timing["total_wall_seconds"] = time.monotonic() - start
+
+		measurement_counts = result_json.get("measurement_counts")
+		circuits = run_request.get("circuits") if isinstance(
+				run_request, dict) else None
+		raw = {
+			"job": {"id": str(job_id), "status": "completed"},
+			"run_request": run_request if isinstance(run_request, dict) else {},
+			"measurement_counts": measurement_counts,
+			"circuits": circuits or [],
+		}
+		from qhw_iqm import normalize_result
+		record = normalize_result(raw, device_id=self._device_id())
+
+		self._last_job = {
+			"id": str(job_id), "status": "completed", "cid": cid,
+			"timing": timing, "shots": shots,
+			"measurements": result_json.get("measurements")}
+		return record
+
+	def _build_iqmjson(self, iqm_circuit, shots, calibration_set_id):
+		# Build an iqm-client RunRequest the same way QRMI's own Qiskit adapter
+		# (qrmi.qiskit_iqm) does, then serialize it: QRMI's task_start expects the
+		# RunRequest JSON as the IQM Server job body. This is the QASM -> IQM JSON
+		# step; the exact RunRequest schema is validated against the live IQM
+		# Server on hardware. Returns (json_str, parsed_dict).
+		try:
+			from iqm.iqm_client import CircuitCompilationOptions
+			from iqm.station_control.interface.models import _build_run_request
+		except Exception as exc:
+			raise DEFwExecutionError(
+				"iqm-client is required to build the IQM job payload for QRMI "
+				f"execution: {exc}") from exc
+		calset = calibration_set_id
+		if calset is not None and not isinstance(calset, str):
+			calset = str(calset)
+		try:
+			run_request = _build_run_request(
+				[iqm_circuit],
+				calibration_set_id=calset,
+				shots=int(shots),
+				options=CircuitCompilationOptions())
+			iqmjson = run_request.model_dump_json()
+		except Exception as exc:
+			raise DEFwExecutionError(
+				f"failed to build the IQM run-request JSON for QRMI: {exc}") \
+				from exc
+		return iqmjson, json.loads(iqmjson)
+
+	def _poll_task(self, job_id, timeout, poll):
+		# Poll QRMI task_status until a terminal state; returns
+		# completed/failed/cancelled (or raises on timeout).
+		deadline = time.monotonic() + max(timeout, 0.0)
+		while True:
+			try:
+				raw = self._qpu().task_status(job_id)
+			except Exception as exc:
+				raise DEFwExecutionError(
+					f"QRMI task_status failed: {exc}") from exc
+			state = _status_str(raw)
+			if "complet" in state:
+				return "completed"
+			if "fail" in state or "error" in state:
+				return "failed"
+			if "cancel" in state:
+				return "cancelled"
+			if time.monotonic() >= deadline:
+				raise DEFwExecutionError(
+					f"QRMI job {job_id} timed out after {timeout}s "
+					f"(last status {state!r})")
+			time.sleep(max(poll, 0.0))
+
+	# --- last-job timing / metadata (from the cached run_circuit job) ----
+
+	def _last_job_for(self, cid):
+		job = self._last_job
+		if not job:
+			raise DEFwExecutionError("QRMI has not run a circuit yet")
+		if cid is not None and str(job.get("cid")) != str(cid):
+			raise DEFwExecutionError(
+				f"QRMI has no job for cid {cid!r} (last job cid "
+				f"{job.get('cid')!r})")
+		return job
 
 	def get_last_job_timing(self, cid=None):
-		self._resource()
-		return self._pending("get_last_job_timing", "qrmi")
+		job = self._last_job_for(cid)
+		return {
+			"cid": job.get("cid"),
+			"job_id": job.get("id"),
+			"status": job.get("status"),
+			"timing": job.get("timing") or {}}
 
 	def get_last_job_metadata(self, cid=None):
-		self._resource()
-		return self._pending("get_last_job_metadata", "qrmi")
+		job = self._last_job_for(cid)
+		return {
+			"cid": job.get("cid"),
+			"job_id": job.get("id"),
+			"status": job.get("status"),
+			"shots": job.get("shots"),
+			"backend": self._descriptor.get("provider", "iqm")}

--- a/services/util/iqm_transcode.py
+++ b/services/util/iqm_transcode.py
@@ -1,0 +1,254 @@
+# Shared OpenQASM -> IQM circuit transcode.
+#
+# Extracted from svc_iqm_qpm/util_iqm.py so both the native IQM service and the
+# QRMI/QDMI shim (svc_lib_qpm) build IQM circuits from OpenQASM the same way.
+# build_iqm_circuit(qasm, dynamic_architecture, mapping) is the entry point: it
+# serializes via iqm.qiskit_iqm when possible and falls back to a manual
+# translation of native OpenQASM gates. dynamic_architecture is the IQM dynamic
+# quantum architecture (a dict or an iqm-client object; to_jsonable coerces it).
+
+from defw_exception import DEFwExecutionError
+from dataclasses import asdict, is_dataclass
+from uuid import UUID
+import logging
+import math
+import re
+
+
+def to_jsonable(value):
+	if value is None or isinstance(value, (str, int, float, bool)):
+		return value
+	if isinstance(value, UUID):
+		return str(value)
+	if isinstance(value, dict):
+		return {str(k): to_jsonable(v) for k, v in value.items()}
+	if isinstance(value, (list, tuple, set, frozenset)):
+		return [to_jsonable(v) for v in value]
+	if is_dataclass(value):
+		return to_jsonable(asdict(value))
+	if hasattr(value, "model_dump"):
+		return to_jsonable(value.model_dump(mode="json"))
+	if hasattr(value, "dict"):
+		return to_jsonable(value.dict())
+	return str(value)
+
+def load_iqm_pulse_module():
+	try:
+		from iqm.pulse import Circuit, CircuitOperation
+	except Exception as exc:
+		raise DEFwExecutionError(
+			f"failed to import iqm.pulse circuit objects: {exc}") from exc
+	return Circuit, CircuitOperation
+
+def active_qubits(dynamic_architecture):
+	data = to_jsonable(dynamic_architecture)
+	qubits = data.get("qubits") or []
+	if not qubits:
+		raise DEFwExecutionError(
+			"IQM dynamic architecture did not report active qubits")
+	return [str(qubit) for qubit in qubits]
+
+def logical_to_physical_qubits(qasm_circuit, dynamic_architecture, mapping):
+	physical = active_qubits(dynamic_architecture)
+	num_qubits = getattr(qasm_circuit, "num_qubits", 0)
+	if mapping:
+		if isinstance(mapping, dict):
+			return {
+				index: str(mapping.get(index, mapping.get(str(index))))
+				for index in range(num_qubits)
+			}
+		return {index: str(value) for index, value in enumerate(mapping)}
+
+	if num_qubits > len(physical):
+		raise DEFwExecutionError(
+			f"circuit requires {num_qubits} qubits but IQM reports "
+			f"{len(physical)} active qubits")
+	return {index: physical[index] for index in range(num_qubits)}
+
+def eval_angle(value):
+	allowed = {"pi": math.pi}
+	try:
+		return float(eval(value, {"__builtins__": {}}, allowed))
+	except Exception as exc:
+		raise DEFwExecutionError(
+			f"unsupported angle expression in OpenQASM: {value!r}") from exc
+
+def split_qasm_statements(qasm):
+	statements = []
+	for line in qasm.splitlines():
+		line = line.split("//", 1)[0].strip()
+		if not line:
+			continue
+		for part in line.split(";"):
+			part = part.strip()
+			if part:
+				statements.append(part)
+	return statements
+
+def load_qiskit_circuit(qasm):
+	try:
+		from qiskit import QuantumCircuit
+		try:
+			from qiskit import qasm2
+			return qasm2.loads(qasm)
+		except Exception:
+			return QuantumCircuit.from_qasm_str(qasm)
+	except Exception as exc:
+		raise DEFwExecutionError(
+			f"failed to parse OpenQASM through qiskit: {exc}") from exc
+
+def serialize_qiskit_to_iqm(qasm, dynamic_architecture, mapping):
+	Circuit, _ = load_iqm_pulse_module()
+	try:
+		from iqm.qiskit_iqm import qiskit_to_iqm
+	except Exception as exc:
+		raise DEFwExecutionError(
+			"iqm.qiskit_iqm is required to serialize qiskit circuits "
+			f"for IQM execution: {exc}") from exc
+
+	qiskit_circuit = load_qiskit_circuit(qasm)
+	index_to_name = logical_to_physical_qubits(
+		qiskit_circuit, dynamic_architecture, mapping)
+	try:
+		instructions = qiskit_to_iqm.serialize_instructions(
+			qiskit_circuit, index_to_name)
+	except Exception as exc:
+		raise DEFwExecutionError(
+			"IQM could not serialize the circuit. Transpile the circuit "
+			f"to IQM-supported native operations first. Error: {exc}") from exc
+
+	return Circuit(
+		name=qiskit_circuit.name or "qfw_iqm_circuit",
+		instructions=tuple(instructions),
+		metadata={"logical_to_physical": index_to_name},
+	)
+
+def parse_ref(ref, qregs):
+	ref = ref.strip()
+	match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\[(\d+)\]$", ref)
+	if match:
+		reg, index = match.group(1), int(match.group(2))
+		if reg not in qregs or index >= qregs[reg]:
+			raise DEFwExecutionError(f"unknown OpenQASM qubit reference {ref}")
+		return [(reg, index)]
+	if ref in qregs:
+		return [(ref, index) for index in range(qregs[ref])]
+	raise DEFwExecutionError(f"unknown OpenQASM qubit reference {ref}")
+
+def build_manual_iqm_circuit(qasm, dynamic_architecture, mapping):
+	Circuit, CircuitOperation = load_iqm_pulse_module()
+	statements = split_qasm_statements(qasm)
+	qregs = {}
+	cregs = {}
+	operations = []
+
+	for statement in statements:
+		if statement.startswith("OPENQASM") or statement.startswith("include"):
+			continue
+		match = re.match(r"^qreg\s+(\w+)\[(\d+)\]$", statement)
+		if match:
+			qregs[match.group(1)] = int(match.group(2))
+			continue
+		match = re.match(r"^creg\s+(\w+)\[(\d+)\]$", statement)
+		if match:
+			cregs[match.group(1)] = int(match.group(2))
+			continue
+
+	if not qregs:
+		raise DEFwExecutionError("OpenQASM input does not define a qreg")
+
+	total_qubits = sum(qregs.values())
+	physical = active_qubits(dynamic_architecture)
+	if total_qubits > len(physical):
+		raise DEFwExecutionError(
+			f"circuit requires {total_qubits} qubits but IQM reports "
+			f"{len(physical)} active qubits")
+
+	ordered = []
+	for reg, size in qregs.items():
+		for index in range(size):
+			ordered.append((reg, index))
+	if mapping:
+		if isinstance(mapping, dict):
+			qubit_map = {
+				key: str(mapping.get(f"{key[0]}[{key[1]}]",
+							 mapping.get(key[1], mapping.get(str(key[1])))))
+				for key in ordered
+			}
+		else:
+			qubit_map = {key: str(mapping[index])
+				     for index, key in enumerate(ordered)}
+	else:
+		qubit_map = {key: physical[index] for index, key in enumerate(ordered)}
+
+	for statement in statements:
+		if statement.startswith(("OPENQASM", "include", "qreg", "creg")):
+			continue
+		if statement.startswith("barrier"):
+			refs = statement[len("barrier"):].strip()
+			locus = []
+			for ref in refs.split(","):
+				locus.extend(qubit_map[key] for key in parse_ref(ref, qregs))
+			operations.append(CircuitOperation(
+				name="barrier", locus=tuple(locus), args={}))
+			continue
+		if statement.startswith("measure"):
+			match = re.match(r"^measure\s+(.+)\s+->\s+(.+)$", statement)
+			if not match:
+				raise DEFwExecutionError(
+					f"unsupported OpenQASM measurement: {statement}")
+			qrefs = parse_ref(match.group(1), qregs)
+			cref = match.group(2).strip()
+			key = "m"
+			match_cref = re.match(r"^(\w+)\[(\d+)\]$", cref)
+			if match_cref:
+				key = f"{match_cref.group(1)}{match_cref.group(2)}"
+			elif cref not in cregs:
+				raise DEFwExecutionError(
+					f"unknown OpenQASM classical reference {cref}")
+			operations.append(CircuitOperation(
+				name="measure",
+				locus=tuple(qubit_map[key] for key in qrefs),
+				args={"key": key},
+			))
+			continue
+		match = re.match(r"^(\w+)(?:\(([^)]*)\))?\s+(.+)$", statement)
+		if not match:
+			raise DEFwExecutionError(
+				f"unsupported OpenQASM statement: {statement}")
+		gate, params, refs = match.group(1), match.group(2), match.group(3)
+		refs = [ref.strip() for ref in refs.split(",")]
+		locus = tuple(qubit_map[key] for ref in refs for key in parse_ref(ref, qregs))
+		if gate == "x":
+			operations.append(CircuitOperation(
+				name="prx", locus=locus, args={"angle": math.pi,
+							       "phase": 0.0}))
+		elif gate == "rx" and params is not None:
+			operations.append(CircuitOperation(
+				name="prx", locus=locus, args={"angle": eval_angle(params),
+							       "phase": 0.0}))
+		elif gate == "ry" and params is not None:
+			operations.append(CircuitOperation(
+				name="prx", locus=locus, args={"angle": eval_angle(params),
+							       "phase": math.pi / 2}))
+		elif gate == "cz":
+			operations.append(CircuitOperation(
+				name="cz", locus=locus, args={}))
+		else:
+			raise DEFwExecutionError(
+				"IQM service can only manually translate native "
+				f"OpenQASM gates x, rx, ry, cz, barrier, measure. "
+				f"Unsupported statement: {statement}")
+
+	return Circuit(
+		name="qfw_iqm_circuit",
+		instructions=tuple(operations),
+		metadata={"logical_to_physical": to_jsonable(qubit_map)},
+	)
+
+def build_iqm_circuit(qasm, dynamic_architecture, mapping):
+	try:
+		return serialize_qiskit_to_iqm(qasm, dynamic_architecture, mapping)
+	except DEFwExecutionError as exc:
+		logging.debug(f"falling back to manual IQM QASM translation: {exc}")
+		return build_manual_iqm_circuit(qasm, dynamic_architecture, mapping)


### PR DESCRIPTION
Follow-on to #24. Wires the **execution facet** on QRMI — the first cut of `run_circuit` + job timing/metadata — using **OpenQASM** as the canonical circuit form (the decision recorded in `openQSE/development-analysis`).

## Two commits

**1. Factor the OpenQASM→IQM transcode into a shared util.** Moves the standalone transcode functions (`build_iqm_circuit` and its helpers: `serialize_qiskit_to_iqm`, `build_manual_iqm_circuit`, `load_qiskit_circuit`, `logical_to_physical_qubits`, `active_qubits`, `load_iqm_pulse_module`, `parse_ref`, `eval_angle`, `split_qasm_statements`, `to_jsonable`) out of `svc_iqm_qpm/util_iqm.py` into `services/util/iqm_transcode.py`, so the shim and the native service build IQM circuits from OpenQASM the same way. The native service re-imports the three names it still uses; no behavior change.

**2. Wire QRMI circuit execution.** `QrmiDriver.run_circuit`:
- takes canonical OpenQASM from `circuit.info`, transcodes it (dynamic architecture from the cached `target()`),
- builds the `iqmjson` the same way QRMI's own Qiskit adapter does (iqm-client `RunRequest` → `model_dump_json()`),
- submits `Payload.IQMServer` → `task_start` → polls `task_status` → `task_result`,
- normalizes counts to `qhw-result-v1` via `qhw-iqm` (the same normalizer the native path uses).

QRMI-for-IQM has no `acquire`/`release`, so there is no reservation step. `get_last_job_timing` / `get_last_job_metadata` report the cached last job. Design doc §13 updated.

## Validation
- `py_compile` + `tabnanny` on all changed files; the moved transcode helpers verified to behave identically post-move.
- Host orchestration test (mocked QRMI resource, real `qhw-iqm`): transcode reuse → submit → poll-to-completion → result assembly → valid `qhw-result-v1`, plus timing/metadata caching, cid-mismatch rejection, and the failed-status path.
- **Validated on live IQM:** the exact iqm-client `RunRequest` schema in `_build_iqmjson` and the submit/poll/result loop (need `iqm-client` + the device). The existing smoke test exercises this via `./qfw_shim_smoke.sh --lib qrmi` (async_run + get_last_job_metadata are in its default sequence).

## Next
QDMI execution via FoMaC `submit_job` as the comparison path; richer job lifecycle.
