### PR TITLE
QFw: descriptor-config wiring, mock-suite repair, and QPM/job correctness fixes

### DIFF
--- a/backends/qfw_qiskit/qfw_job.py
+++ b/backends/qfw_qiskit/qfw_job.py
@@ -168,6 +168,16 @@ class QFwJob(Job):
 		qpm_results = self._result_reader(self._cid_list)
 		self._result_wait_time = time.time() - res_wait_start
 
+		if not qpm_results:
+			# _result_reader returns early when it times out; with no completed
+			# circuits there is nothing to assemble and the per-circuit `out`
+			# referenced below (and in the job-level result) never binds. Fail
+			# loudly with the cause instead of raising a bare NameError.
+			raise DEFwError(
+				f"QFw job {self._job_id} returned no circuit results within "
+				f"{self._backend.COMPLETION_TIMEOUT_SEC}s "
+				f"(expected {len(self._cid_list)} circuit(s))")
+
 		for qr in qpm_results:
 			res = qr['res']
 			self._backend.log_statistics(res)

--- a/backends/qfw_qiskit/qfw_lookup_service.py
+++ b/backends/qfw_qiskit/qfw_lookup_service.py
@@ -66,7 +66,11 @@ def get_qpm(qpm_type=-1, qpm_cap=-1):
 	try:
 		test_qpm(qpm_api)
 	except Exception as e:
+		# The probe failed, so the reserved QPM is unusable. Tear it down and
+		# propagate -- returning the now shut-down handle would only defer the
+		# failure to the first real call against a dead resource.
 		logging.debug(f"QPM ran into an exception {e}")
 		qpm_api.shutdown()
+		raise
 
 	return qpm_api

--- a/services/util/device_access.py
+++ b/services/util/device_access.py
@@ -124,7 +124,7 @@ def select_qpu(device_config, path, provider=None):
 		or device.get("quantum_computer")
 		or device_id)
 
-	return {
+	selected = {
 		"device_id": device_id,
 		"provider_device_id": str(provider_device_id).strip(),
 		"provider": device_provider or (provider.lower() if provider else ""),
@@ -132,6 +132,19 @@ def select_qpu(device_config, path, provider=None):
 		"credential_db": resolve_relative_path(str(credential_db), path),
 		"quantum_computer": str(provider_device_id).strip(),
 	}
+
+	# Pass through the optional shim descriptor fields (svc_lib_qpm's
+	# resolve_descriptor reads these off the selected device; see
+	# docs/qpu-frontend-contract.md section 5). Only forward keys that are
+	# actually configured so descriptor.py can apply its own defaults for the
+	# rest -- a key present with a None value would otherwise defeat the
+	# `device.get(key, DEFAULT)` fallbacks. The native resolve_device_access
+	# path ignores these keys, so forwarding them here is harmless.
+	for key in ("libraries", "preference", "caps", "execution-owner", "execution_owner"):
+		if key in device:
+			selected[key] = device[key]
+
+	return selected
 
 
 def get_user_records(credential_db):

--- a/services/util/qpm/util_qpm.py
+++ b/services/util/qpm/util_qpm.py
@@ -219,7 +219,7 @@ class UTIL_QPM:
 		if not qpm_initialized:
 			raise DEFwNotReady("QPM has not initialized properly")
 
-		r = self.qrc.peak_cq()
+		r = self.qrc.peak_cq(cid)
 
 		if not r:
 			if cid:

--- a/tests/mock/conftest.py
+++ b/tests/mock/conftest.py
@@ -105,6 +105,9 @@ def _install_defw_stubs():
 		class DEFwExecutionError(DEFwError):
 			pass
 
+		class DEFwReserveError(DEFwError):
+			pass
+
 		class DEFwDumper:
 			pass
 
@@ -114,6 +117,7 @@ def _install_defw_stubs():
 		defw_exception.DEFwNotFound = DEFwNotFound
 		defw_exception.DEFwAgentNotFound = DEFwAgentNotFound
 		defw_exception.DEFwExecutionError = DEFwExecutionError
+		defw_exception.DEFwReserveError = DEFwReserveError
 		defw_exception.DEFwDumper = DEFwDumper
 		sys.modules["defw_exception"] = defw_exception
 
@@ -139,6 +143,7 @@ def _install_defw_stubs():
 
 		defw_app_util.defw_get_resource_mgr = defw_get_resource_mgr
 		defw_app_util.defw_reserve_service_by_name = defw_reserve_service_by_name
+		defw_app_util.SYSTEM_UP_TIMEOUT = 40
 		sys.modules["defw_app_util"] = defw_app_util
 
 	if "defw_event_baseapi" not in sys.modules:
@@ -191,7 +196,11 @@ def _install_defw_stubs():
 			def exit(self):
 				self.exit_called = True
 
+		def connect_to_resource(services, name):
+			raise AssertionError("defw.connect_to_resource must be patched in tests")
+
 		defw.me = _Runtime()
+		defw.connect_to_resource = connect_to_resource
 		sys.modules["defw"] = defw
 
 
@@ -409,6 +418,12 @@ def _install_qiskit_stubs():
 	quantum_info = types.ModuleType("qiskit.quantum_info")
 	quantum_info.Pauli = type("Pauli", (), {})
 	quantum_info.PauliList = type("PauliList", (), {})
+
+	class Statevector:
+		def __init__(self, data=None):
+			self.data = data
+
+	quantum_info.Statevector = Statevector
 	sys.modules["qiskit.quantum_info"] = quantum_info
 
 	primitives_base = types.ModuleType("qiskit.primitives.base")

--- a/tests/mock/conftest.py
+++ b/tests/mock/conftest.py
@@ -102,6 +102,9 @@ def _install_defw_stubs():
 		class DEFwAgentNotFound(DEFwError):
 			pass
 
+		class DEFwExecutionError(DEFwError):
+			pass
+
 		class DEFwDumper:
 			pass
 
@@ -110,6 +113,7 @@ def _install_defw_stubs():
 		defw_exception.DEFwInProgress = DEFwInProgress
 		defw_exception.DEFwNotFound = DEFwNotFound
 		defw_exception.DEFwAgentNotFound = DEFwAgentNotFound
+		defw_exception.DEFwExecutionError = DEFwExecutionError
 		defw_exception.DEFwDumper = DEFwDumper
 		sys.modules["defw_exception"] = defw_exception
 

--- a/tests/mock/conftest.py
+++ b/tests/mock/conftest.py
@@ -108,6 +108,9 @@ def _install_defw_stubs():
 		class DEFwReserveError(DEFwError):
 			pass
 
+		class DEFwOutOfResources(DEFwError):
+			pass
+
 		class DEFwDumper:
 			pass
 
@@ -118,6 +121,7 @@ def _install_defw_stubs():
 		defw_exception.DEFwAgentNotFound = DEFwAgentNotFound
 		defw_exception.DEFwExecutionError = DEFwExecutionError
 		defw_exception.DEFwReserveError = DEFwReserveError
+		defw_exception.DEFwOutOfResources = DEFwOutOfResources
 		defw_exception.DEFwDumper = DEFwDumper
 		sys.modules["defw_exception"] = defw_exception
 
@@ -202,6 +206,49 @@ def _install_defw_stubs():
 		defw.me = _Runtime()
 		defw.connect_to_resource = connect_to_resource
 		sys.modules["defw"] = defw
+
+	if "api_events" not in sys.modules:
+		api_events = types.ModuleType("api_events")
+
+		class Event:
+			def __init__(self, evtype, payload):
+				self.evtype = evtype
+				self.payload = payload
+
+		class BaseEventAPI:
+			def __init__(self, *args, **kwargs):
+				self.args = args
+				self.kwargs = kwargs
+
+		api_events.Event = Event
+		api_events.BaseEventAPI = BaseEventAPI
+		sys.modules["api_events"] = api_events
+
+	if "defw_util" not in sys.modules:
+		# The real defw_util pulls in the defw_cmd/native stack; stub only the
+		# helpers the QPM utility modules import at load time. They are not
+		# exercised by the mock tests (which drive individual methods), so simple
+		# reference implementations are enough.
+		defw_util = types.ModuleType("defw_util")
+
+		def expand_host_list(host_spec):
+			if not host_spec:
+				return []
+			return [h for h in str(host_spec).split(",") if h]
+
+		def round_half_up(value):
+			return int(value + 0.5)
+
+		def round_to_nearest_power_of_two(value):
+			power = 1
+			while power < value:
+				power *= 2
+			return power
+
+		defw_util.expand_host_list = expand_host_list
+		defw_util.round_half_up = round_half_up
+		defw_util.round_to_nearest_power_of_two = round_to_nearest_power_of_two
+		sys.modules["defw_util"] = defw_util
 
 
 def _install_qiskit_stubs():

--- a/tests/mock/test_descriptor_config.py
+++ b/tests/mock/test_descriptor_config.py
@@ -1,0 +1,140 @@
+# Guards the shim descriptor-config wiring: select_qpu() must forward the
+# optional per-resource descriptor fields (libraries, preference, caps,
+# execution-owner) so svc_lib_qpm's resolve_descriptor() can honor them. These
+# keys used to be dropped by select_qpu's fixed whitelist, which silently
+# defeated the descriptor customization documented in
+# docs/qpu-frontend-contract.md section 5.
+#
+# Everything here works on plain dicts, so it needs neither PyYAML nor a live
+# device: select_qpu() takes the parsed config dict directly, and the
+# resolve_descriptor() end-to-end check stubs the config loader.
+
+import importlib.util
+import pathlib
+import sys
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SERVICES = str(REPO_ROOT / "services")
+if SERVICES not in sys.path:
+	sys.path.insert(0, SERVICES)
+
+import util.device_access as device_access  # noqa: E402
+
+
+DEVICE_WITH_DESCRIPTOR = {
+	"provider": "iqm",
+	"provider-device-id": "cocos",
+	"url": "https://example.org/",
+	"credential-db": "creds.json",
+	"libraries": ["qrmi"],
+	"preference": "qrmi",
+	"execution-owner": "qrmi",
+	"caps": {"get_device_info": ["qrmi"], "run_circuit": ["qrmi"]},
+}
+
+BARE_DEVICE = {
+	"provider": "iqm",
+	"url": "https://example.org/",
+	"credential-db": "creds.json",
+}
+
+DESCRIPTOR_KEYS = (
+	"libraries", "preference", "caps", "execution-owner", "execution_owner")
+
+
+def _config(device, device_id="dev"):
+	return {"qpus": {device_id: device}}
+
+
+def _load_descriptor():
+	# Load descriptor.py directly, bypassing svc_lib_qpm/__init__.py (which pulls
+	# in the whole DEFw/api_events stack that is not available under tests/mock).
+	spec = importlib.util.spec_from_file_location(
+		"svc_lib_qpm_descriptor",
+		str(REPO_ROOT / "services" / "svc_lib_qpm" / "descriptor.py"))
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+# --- select_qpu(): the fix site --------------------------------------------
+
+def test_select_qpu_passes_through_descriptor_fields(monkeypatch):
+	monkeypatch.delenv(device_access.QPU_DEVICE_ENV, raising=False)
+	selected = device_access.select_qpu(
+		_config(DEVICE_WITH_DESCRIPTOR), "cfg.yaml", provider="iqm")
+	assert selected["libraries"] == ["qrmi"]
+	assert selected["preference"] == "qrmi"
+	assert selected["execution-owner"] == "qrmi"
+	assert selected["caps"] == {
+		"get_device_info": ["qrmi"], "run_circuit": ["qrmi"]}
+
+
+def test_select_qpu_omits_absent_descriptor_fields(monkeypatch):
+	# Absent keys must NOT appear, so descriptor.py's device.get(key, DEFAULT)
+	# fallbacks apply. Forwarding a key with a None value would defeat them.
+	monkeypatch.delenv(device_access.QPU_DEVICE_ENV, raising=False)
+	selected = device_access.select_qpu(
+		_config(BARE_DEVICE), "cfg.yaml", provider="iqm")
+	for key in DESCRIPTOR_KEYS:
+		assert key not in selected
+
+
+def test_select_qpu_preserves_native_fields(monkeypatch):
+	# Regression guard: the descriptor passthrough must not disturb the native
+	# fields the IQM access path depends on.
+	monkeypatch.delenv(device_access.QPU_DEVICE_ENV, raising=False)
+	selected = device_access.select_qpu(
+		_config(DEVICE_WITH_DESCRIPTOR), "cfg.yaml", provider="iqm")
+	assert selected["device_id"] == "dev"
+	assert selected["provider"] == "iqm"
+	assert selected["provider_device_id"] == "cocos"
+	assert selected["url"] == "https://example.org/"
+	assert selected["credential_db"].endswith("creds.json")
+
+
+def test_select_qpu_accepts_execution_owner_underscore(monkeypatch):
+	# Both spellings are honored; libraries pass through raw (resolve_descriptor
+	# splits a comma string via _as_list).
+	monkeypatch.delenv(device_access.QPU_DEVICE_ENV, raising=False)
+	device = dict(BARE_DEVICE, execution_owner="qdmi", libraries="qrmi, qdmi")
+	selected = device_access.select_qpu(
+		_config(device), "cfg.yaml", provider="iqm")
+	assert selected["execution_owner"] == "qdmi"
+	assert selected["libraries"] == "qrmi, qdmi"
+
+
+# --- resolve_descriptor(): end-to-end over select_qpu ----------------------
+
+def test_resolve_descriptor_honors_configured_fields(monkeypatch):
+	descriptor = _load_descriptor()
+	monkeypatch.setattr(
+		device_access, "device_access_config_path", lambda: "cfg.yaml")
+	monkeypatch.setattr(
+		device_access, "load_yaml_config",
+		lambda path: _config(DEVICE_WITH_DESCRIPTOR))
+	monkeypatch.setenv(device_access.QPU_DEVICE_ENV, "dev")
+
+	resolved = descriptor.resolve_descriptor()
+	assert resolved["libraries"] == ["qrmi"]
+	assert resolved["preference"] == "qrmi"
+	assert resolved["execution_owner"] == "qrmi"
+	assert resolved["caps"] == {
+		"get_device_info": ["qrmi"], "run_circuit": ["qrmi"]}
+
+
+def test_resolve_descriptor_defaults_when_unconfigured(monkeypatch):
+	descriptor = _load_descriptor()
+	monkeypatch.setattr(
+		device_access, "device_access_config_path", lambda: "cfg.yaml")
+	monkeypatch.setattr(
+		device_access, "load_yaml_config",
+		lambda path: _config(BARE_DEVICE))
+	monkeypatch.setenv(device_access.QPU_DEVICE_ENV, "dev")
+
+	resolved = descriptor.resolve_descriptor()
+	assert resolved["libraries"] == descriptor.DEFAULT_LIBRARIES
+	assert resolved["preference"] == descriptor.DEFAULT_PREFERENCE
+	assert resolved["execution_owner"] == descriptor.DEFAULT_EXECUTION_OWNER
+	assert resolved["caps"] == descriptor.DEFAULT_CAPS

--- a/tests/mock/test_qfw_job.py
+++ b/tests/mock/test_qfw_job.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.mock.fakes import FakeEventAPI, FakeQPM, make_result_event
 
 
@@ -80,6 +82,30 @@ def test_qfw_job_result_maps_counts_into_qiskit_result(monkeypatch):
 	# Memory is emitted in Qiskit's hex format (QFwSamplerV2 parses it via
 	# int(sample, 16)); "00" -> 0x0, "11" -> 0x3.
 	assert result_entry["data"]["memory"] == ["0x0", "0x0", "0x3"]
+
+
+def test_qfw_job_result_raises_when_no_results(monkeypatch):
+	import qfw_qiskit.qfw_job as qfw_job
+	from defw_exception import DEFwError
+
+	fake_qpm = FakeQPM(cids=["cid-1"])
+	event_api = FakeEventAPI()  # no result events ever arrive
+	backend = FakeBackend()
+	circuit = qfw_job.QuantumCircuit(1, name="timeout-path")
+	options = {"shots": 2, "seed": 1, "seed_simulator": 1}
+
+	monkeypatch.setattr(qfw_job.qasm2, "dumps", lambda circ: "OPENQASM 2.0;")
+	# COMPLETION_TIMEOUT_SEC == 0 makes _result_reader return immediately with no
+	# completed circuits -- a real timeout without the wall-clock wait.
+	monkeypatch.setattr(backend, "COMPLETION_TIMEOUT_SEC", 0)
+
+	job = qfw_job.QFwJob(backend, fake_qpm, event_api, circuit, options)
+	job.submit()
+
+	# With no results the per-circuit `out` never binds; result() must fail
+	# with a clear error naming the cause, not a bare NameError.
+	with pytest.raises(DEFwError, match="no circuit results"):
+		job.result()
 
 
 def test_qfw_job_submit_propagates_async_run_errors(monkeypatch):

--- a/tests/mock/test_qfw_job.py
+++ b/tests/mock/test_qfw_job.py
@@ -4,9 +4,13 @@ from tests.mock.fakes import FakeEventAPI, FakeQPM, make_result_event
 class FakeBackend:
 	COMPLETION_TIMEOUT_SEC = 5
 
-	def __init__(self):
+	def __init__(self, statevector=False):
 		self.logged_results = []
 		self.dump_called = False
+		self._statevector = statevector
+
+	def returns_statevector(self):
+		return self._statevector
 
 	def log_statistics(self, result):
 		self.logged_results.append(result)
@@ -73,7 +77,9 @@ def test_qfw_job_result_maps_counts_into_qiskit_result(monkeypatch):
 	assert result_entry["header"]["name"] == "bell"
 	assert result_entry["header"]["memory_slots"] == 2
 	assert result_entry["shots"] == 3
-	assert result_entry["data"]["memory"] == ["00", "00", "11"]
+	# Memory is emitted in Qiskit's hex format (QFwSamplerV2 parses it via
+	# int(sample, 16)); "00" -> 0x0, "11" -> 0x3.
+	assert result_entry["data"]["memory"] == ["0x0", "0x0", "0x3"]
 
 
 def test_qfw_job_submit_propagates_async_run_errors(monkeypatch):

--- a/tests/mock/test_qfw_lookup_service.py
+++ b/tests/mock/test_qfw_lookup_service.py
@@ -1,59 +1,126 @@
+import pytest
+
 from tests.mock.fakes import FakeQPM
+
+
+class FakeServiceInfo:
+	def __init__(self, provider):
+		self._provider = provider
+
+	def get_properties(self):
+		return {"provider": self._provider}
+
+
+class FakeResourceMgr:
+	def __init__(self, services):
+		self._services = services
+		self.calls = []
+
+	def get_services(self, name, qpm_type, qpm_cap):
+		self.calls.append((name, qpm_type, qpm_cap))
+		return list(self._services)
+
+
+class ConnectRecorder:
+	"""Stand-in for defw.connect_to_resource that records the chosen services."""
+
+	def __init__(self, qpm):
+		self._qpm = qpm
+		self.services = None
+		self.name = None
+
+	def __call__(self, services, name):
+		self.services = services
+		self.name = name
+		return [self._qpm]
 
 
 def test_get_qpm_returns_reserved_service(monkeypatch):
 	import qfw_qiskit.qfw_lookup_service as lookup_service
 
 	fake_qpm = FakeQPM()
+	info = FakeServiceInfo("iqm")
+	rmgr = FakeResourceMgr([info])
+	connect = ConnectRecorder(fake_qpm)
 
-	monkeypatch.setattr(lookup_service, "defw_get_resource_mgr", lambda: "rmgr")
-	monkeypatch.setattr(
-		lookup_service,
-		"defw_reserve_service_by_name",
-		lambda rmgr, name, qpm_type, qpm_cap: [fake_qpm],
-	)
+	monkeypatch.delenv("QFW_QPM_IMPL", raising=False)  # default impl == iqm
+	monkeypatch.setattr(lookup_service, "defw_get_resource_mgr", lambda: rmgr)
+	monkeypatch.setattr(lookup_service.defw, "connect_to_resource", connect)
 
 	result = lookup_service.get_qpm(qpm_type=4, qpm_cap=2)
 
 	assert result is fake_qpm
 	assert fake_qpm.shutdown_called is False
+	assert rmgr.calls == [("QPM", 4, 2)]
+	assert connect.services == [info]
+	assert connect.name == "QPM"
 
 
-def test_get_qpm_shuts_down_failed_service_probe(monkeypatch):
+def test_get_qpm_selects_impl_by_provider(monkeypatch):
+	import qfw_qiskit.qfw_lookup_service as lookup_service
+
+	iqm_info = FakeServiceInfo("iqm")
+	shim_info = FakeServiceInfo("shim")
+	rmgr = FakeResourceMgr([iqm_info, shim_info])
+	connect = ConnectRecorder(FakeQPM())
+
+	# resmgr matching ignores the 'provider' property, so both come back; the
+	# QFW_QPM_IMPL selection must pick the requested one.
+	monkeypatch.setenv("QFW_QPM_IMPL", "shim")
+	monkeypatch.setattr(lookup_service, "defw_get_resource_mgr", lambda: rmgr)
+	monkeypatch.setattr(lookup_service.defw, "connect_to_resource", connect)
+
+	lookup_service.get_qpm(qpm_type=4, qpm_cap=2)
+
+	assert connect.services == [shim_info]
+
+
+def test_get_qpm_falls_back_when_requested_impl_absent(monkeypatch):
+	import qfw_qiskit.qfw_lookup_service as lookup_service
+
+	iqm_info = FakeServiceInfo("iqm")
+	rmgr = FakeResourceMgr([iqm_info])
+	connect = ConnectRecorder(FakeQPM())
+
+	# No QPM advertises provider 'shim'; fall back to whatever matched.
+	monkeypatch.setenv("QFW_QPM_IMPL", "shim")
+	monkeypatch.setattr(lookup_service, "defw_get_resource_mgr", lambda: rmgr)
+	monkeypatch.setattr(lookup_service.defw, "connect_to_resource", connect)
+
+	lookup_service.get_qpm(qpm_type=4, qpm_cap=2)
+
+	assert connect.services == [iqm_info]
+
+
+def test_get_qpm_raises_and_shuts_down_on_probe_failure(monkeypatch):
 	import qfw_qiskit.qfw_lookup_service as lookup_service
 
 	fake_qpm = FakeQPM(test_error=RuntimeError("probe failed"))
+	rmgr = FakeResourceMgr([FakeServiceInfo("iqm")])
 
-	monkeypatch.setattr(lookup_service, "defw_get_resource_mgr", lambda: "rmgr")
+	monkeypatch.delenv("QFW_QPM_IMPL", raising=False)
+	monkeypatch.setattr(lookup_service, "defw_get_resource_mgr", lambda: rmgr)
 	monkeypatch.setattr(
-		lookup_service,
-		"defw_reserve_service_by_name",
-		lambda rmgr, name, qpm_type, qpm_cap: [fake_qpm],
-	)
+		lookup_service.defw, "connect_to_resource", ConnectRecorder(fake_qpm))
 
-	result = lookup_service.get_qpm(qpm_type=4, qpm_cap=2)
+	# A failed probe must not hand back a shut-down handle: it tears the QPM
+	# down and propagates the failure.
+	with pytest.raises(RuntimeError, match="probe failed"):
+		lookup_service.get_qpm(qpm_type=4, qpm_cap=2)
 
-	assert result is fake_qpm
 	assert fake_qpm.shutdown_called is True
 
 
-def test_get_qpm_propagates_reservation_failures(monkeypatch):
+def test_get_qpm_raises_when_no_qpm_available(monkeypatch):
 	import qfw_qiskit.qfw_lookup_service as lookup_service
+	from defw_exception import DEFwReserveError
 
-	monkeypatch.setattr(lookup_service, "defw_get_resource_mgr", lambda: "rmgr")
+	rmgr = FakeResourceMgr([])  # resmgr never returns a QPM
 
-	def raise_reservation_error(*args, **kwargs):
-		raise RuntimeError("reserve failed")
+	monkeypatch.delenv("QFW_QPM_IMPL", raising=False)
+	monkeypatch.setattr(lookup_service, "defw_get_resource_mgr", lambda: rmgr)
+	# Don't actually sleep through the connect-retry loop.
+	monkeypatch.setattr(lookup_service, "sleep", lambda _seconds: None)
 
-	monkeypatch.setattr(
-		lookup_service,
-		"defw_reserve_service_by_name",
-		raise_reservation_error,
-	)
-
-	try:
+	with pytest.raises(DEFwReserveError):
 		lookup_service.get_qpm(qpm_type=4, qpm_cap=2)
-	except RuntimeError as exc:
-		assert str(exc) == "reserve failed"
-	else:
-		raise AssertionError("expected reservation failure to propagate")

--- a/tests/mock/test_qfw_qpm_cq.py
+++ b/tests/mock/test_qfw_qpm_cq.py
@@ -1,0 +1,87 @@
+# Guards the completion-queue lookups on UTIL_QPM. peek_cq(cid) used to call
+# self.qrc.peak_cq() with no argument, dropping the cid and always returning the
+# head of the queue -- unlike its sibling read_cq(cid), which forwards it. These
+# tests pin both methods to forward the cid.
+#
+# UTIL_QPM.__init__ wires up DEFw host resources, so the methods are exercised on
+# an instance built with __new__ (only qrc and the module's qpm_initialized flag
+# are needed here).
+
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SERVICES = str(REPO_ROOT / "services")
+if SERVICES not in sys.path:
+	sys.path.insert(0, SERVICES)
+
+import util.qpm.util_qpm as util_qpm  # noqa: E402
+
+
+class RecordingQRC:
+	def __init__(self, result=None):
+		self.result = result
+		self.peek_cid = "UNSET"
+		self.read_cid = "UNSET"
+
+	def peak_cq(self, cid=None):
+		self.peek_cid = cid
+		return self.result
+
+	def read_cq(self, cid=None):
+		self.read_cid = cid
+		return self.result
+
+
+def _make_qpm(qrc):
+	qpm = util_qpm.UTIL_QPM.__new__(util_qpm.UTIL_QPM)
+	qpm.qrc = qrc
+	qpm.all_results = []
+	return qpm
+
+
+def test_peek_cq_forwards_cid(monkeypatch):
+	monkeypatch.setattr(util_qpm, "qpm_initialized", True)
+	qrc = RecordingQRC(result={"cid": "cid-7"})
+	qpm = _make_qpm(qrc)
+
+	out = qpm.peek_cq("cid-7")
+
+	assert qrc.peek_cid == "cid-7"
+	assert out == {"cid": "cid-7"}
+
+
+def test_peek_cq_raises_in_progress_when_absent(monkeypatch):
+	monkeypatch.setattr(util_qpm, "qpm_initialized", True)
+	qrc = RecordingQRC(result=None)
+	qpm = _make_qpm(qrc)
+
+	with pytest.raises(util_qpm.DEFwInProgress):
+		qpm.peek_cq("cid-x")
+
+	# The cid still reaches the queue (so a targeted peek does not fall back to
+	# the head of the queue).
+	assert qrc.peek_cid == "cid-x"
+
+
+def test_peek_cq_requires_initialization(monkeypatch):
+	monkeypatch.setattr(util_qpm, "qpm_initialized", False)
+	qpm = _make_qpm(RecordingQRC())
+
+	with pytest.raises(util_qpm.DEFwNotReady):
+		qpm.peek_cq("cid-x")
+
+
+def test_read_cq_forwards_cid(monkeypatch):
+	# Sibling guard: read_cq already forwarded the cid; keep the two consistent.
+	monkeypatch.setattr(util_qpm, "qpm_initialized", True)
+	qrc = RecordingQRC(result={"cid": "cid-9"})
+	qpm = _make_qpm(qrc)
+
+	out = qpm.read_cq("cid-9")
+
+	assert qrc.read_cid == "cid-9"
+	assert out == {"cid": "cid-9"}
+	assert qpm.all_results == [{"cid": "cid-9"}]


### PR DESCRIPTION
## Summary

A full read-through of the QFw Python code surfaced several correctness bugs
plus a broken mock-test suite. This PR fixes the bugs, each with a regression
test, and repairs `tests/mock` so `ci-mock` is green again.

## Fixes

- **Shim descriptor config was silently ignored.** `select_qpu()` returned a
  fixed whitelist of keys, so the per-resource descriptor fields
  (`libraries`, `preference`, `caps`, `execution-owner`) that
  `svc_lib_qpm/descriptor.py` reads never survived — every resource fell back
  to the built-in defaults, making the descriptor customization in
  `docs/qpu-frontend-contract.md` §5 a no-op. `select_qpu()` now forwards those
  fields when present (absent keys are omitted so the `.get(key, DEFAULT)`
  fallbacks still apply). `services/util/device_access.py`.

- **`get_qpm()` returned a shut-down QPM.** On a failed test-probe it tore the
  QPM down and then returned the dead handle, deferring the failure to the first
  real call. It now propagates the exception after shutdown.
  `backends/qfw_qiskit/qfw_lookup_service.py`.

- **`QFwJob.result()` raised `UnboundLocalError` on a completion timeout.** The
  job-level result referenced a per-circuit `out` that only binds inside the
  results loop; when the reader timed out with zero completed circuits the loop
  never ran. It now raises a `DEFwError` naming the timeout and expected circuit
  count. `backends/qfw_qiskit/qfw_job.py`.

- **`UTIL_QPM.peek_cq(cid)` ignored its argument.** It called
  `self.qrc.peak_cq()` with no `cid` (unlike its sibling `read_cq`), always
  returning the head of the queue. It now forwards the `cid`.
  `services/util/qpm/util_qpm.py`.

## Mock-suite repair

`tests/mock` had drifted from the code and was failing to collect: missing
stubs (`qiskit.quantum_info.Statevector`, `defw_app_util.SYSTEM_UP_TIMEOUT`,
`defw.connect_to_resource`, `defw_exception.DEFwReserveError`) and two stale
tests (`FakeBackend` predating `returns_statevector()` and the Qiskit hex memory
format; `test_qfw_lookup_service` monkeypatching the removed
`defw_reserve_service_by_name`). Stubs added and the two tests realigned with
the current modules.

## Testing

`tests/mock` passes (24 tests) under a pytest-only environment matching CI. Each
fix has a regression test that was confirmed to fail without the corresponding
code change. No new `flake8` warnings in the linted trees.

## Follow-ups (not in this PR)

- A related natural-sort `TypeError` in the `qhw-iqm` submodule
  (`_natural_qubit_key` mixing `int`/`str` sort keys) is being routed to
  `openQSE/qhw-iqm` separately, since it lives outside this repo.
- Pre-existing `ci-syntax` (flake8) warnings across `services/` are untouched
  here; this PR introduces none of its own.
