### PR TITLE
QFw: propagate DEFw transport selection to launched agents

### DIFF
--- a/setup/qfw_setup.py
+++ b/setup/qfw_setup.py
@@ -106,6 +106,12 @@ def get_external_defw_env():
 				'DEFW_EXTERNAL_SERVICE_APIS_PATH',
 				'PATH',
 				'LD_LIBRARY_PATH',
+				# DEFw message transport selection. These must reach the
+				# resmgr and service agents (launched with this curated
+				# environment) so they pick the same transport as the rest
+				# of the run; otherwise they silently default to TCP.
+				'DEFW_TRANSPORT',
+				'DEFW_OFI_PROVIDER',
 				'QFW_TMP_PATH',
 				'QFW_RUN_ID',
 				'QFW_RUN_TMP_PATH',


### PR DESCRIPTION
## Summary

Propagate the DEFw message-transport selection to the launched resmgr and
service agents.

Companion to **[openQSE/DEFw#15](https://github.com/openQSE/DEFw/pull/15)**,
which adds a libfabric/OFI transport selected via `DEFW_TRANSPORT` /
`DEFW_OFI_PROVIDER`. The resmgr and service agents are launched with a curated
environment built by `get_external_defw_env()` in `setup/qfw_setup.py`, which
copies only an allowlist of keys. Those two variables were not on the list, so
the agents never saw the selection and silently stayed on TCP even when the run
requested OFI.

Add `DEFW_TRANSPORT` and `DEFW_OFI_PROVIDER` to the allowlist so the resmgr and
services select the same transport as the rest of the run.

## Validation

In the QFw-SLURM-Cluster container, `DEFW_TRANSPORT=ofi ./qfw_mpi_smoke.sh`:
before this change the resmgr/service defaulted to TCP; after it, both bring up
the OFI endpoint and RPC flows over the fabric (verified with #15 over the tcp
and sm2 providers, 16 RPC sends / 16 recvs each, `status: ok`).

## Merge ordering

Should merge together with #15 — this change is only meaningful once DEFw
understands `DEFW_TRANSPORT`. It is inert on its own (the extra keys are simply
absent from the environment on a stock DEFw).
