### PR TITLE
QFw: fix two hardware-only breakages in shim circuit execution

### DIFF
--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -251,11 +251,19 @@ class QdmiDriver(BaseDriver):
 		# schema on hardware.
 		from util.iqm_transcode import to_jsonable
 		try:
+			# to_json_dict() is typed to take a dict, but build_iqm_circuit
+			# hands us an iqm.pulse Circuit *dataclass* (no model_dump), so it
+			# must be coerced first -- passing the object straight in raises
+			# "Object contains values that are not JSON serializable". The QRMI
+			# leg never hit this because pydantic's RunRequest coerced the same
+			# object for it. to_jsonable handles dataclasses/pydantic/UUIDs;
+			# iqm-client's canonical encoder then applies on top when present.
+			payload = to_jsonable(iqm_circuit)
 			try:
 				from iqm.iqm_client.util import to_json_dict
-				payload = to_json_dict(iqm_circuit)
+				payload = to_json_dict(payload)
 			except ImportError:
-				payload = to_jsonable(iqm_circuit)
+				pass
 			return json.dumps(payload)
 		except Exception as exc:
 			raise DEFwExecutionError(

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -356,8 +356,7 @@ class QrmiDriver(BaseDriver):
 		# step; the exact RunRequest schema is validated against the live IQM
 		# Server on hardware. Returns (json_str, parsed_dict).
 		try:
-			from iqm.iqm_client import CircuitCompilationOptions
-			from iqm.station_control.interface.models import _build_run_request
+			from iqm.station_control.interface.models import RunRequest
 		except Exception as exc:
 			raise DEFwExecutionError(
 				"iqm-client is required to build the IQM job payload for QRMI "
@@ -366,11 +365,15 @@ class QrmiDriver(BaseDriver):
 		if calset is not None and not isinstance(calset, str):
 			calset = str(calset)
 		try:
-			run_request = _build_run_request(
-				[iqm_circuit],
+			# iqm-client >= 34 dropped the private _build_run_request helper.
+			# RunRequest (a TypeAlias for PostJobsRequest) is built directly:
+			# every compilation option the helper set now has a model default.
+			# qubit_mapping stays None because build_iqm_circuit already emits
+			# physical qubit names (see logical_to_physical_qubits).
+			run_request = RunRequest(
+				circuits=[iqm_circuit],
 				calibration_set_id=calset,
-				shots=int(shots),
-				options=CircuitCompilationOptions())
+				shots=int(shots))
 			iqmjson = run_request.model_dump_json()
 		except Exception as exc:
 			raise DEFwExecutionError(


### PR DESCRIPTION
Both execution legs of the QRMI/QDMI shim failed on real hardware. Neither failure is reproducible against a mock, and both are in already-merged code (#25, #26). Found while running the shim smoke test against the ORNL IQM q20.

## 1. QRMI: removed private iqm-client helper

`qrmi_driver._build_iqmjson` imported `_build_run_request` from `iqm.station_control.interface.models`. That helper is private and is gone in **iqm-client 34.0.1**, so `run_circuit` raised `ImportError` before reaching the device on any current install.

Now constructs `RunRequest` directly. It is public and stable (`RunRequest: TypeAlias = PostJobsRequest`, and the upstream model carries a *"Do **not** rename RunRequest model!"* comment), and every compilation option the helper set now has a model default. `qubit_mapping` stays `None` because `build_iqm_circuit` already emits physical qubit names.

## 2. QDMI: dataclass passed to a dict-only serializer

`qdmi_driver._serialize_program` passed the transcoded circuit straight to iqm-client's `to_json_dict()`, which is typed `dict[str, Any]`. `build_iqm_circuit` returns an `iqm.pulse.circuit_operations.Circuit` — a **dataclass**, no `model_dump` — so every QDMI `run_circuit` failed with `Object contains values that are not JSON serializable`.

The QRMI leg never hit this because it hands the same object to pydantic via `RunRequest(circuits=[...])`, which coerces the dataclass for free; only the QDMI leg serializes it itself. A `to_jsonable()` fallback already existed but was guarded by `except ImportError`, so it fired only if the *import* failed, never if the serialization did.

Now coerces with `to_jsonable()` first, then applies iqm-client's canonical encoder to the resulting dict.

## Validation

Against the physical ORNL IQM q20, `--shots 10`, circuit `x q[0]; measure`:

| | QRMI | QDMI |
|---|---|---|
| result | `rc: 0`, `counts {'1': 10}` | `rc: 0`, `counts {'1': 10}` |
| schema | `qhw-result-v1` | `qhw-result-v1` |

OpenQASM `x q[0]` transcodes to IQM-native `prx(angle=pi, phase=0)` on `QB1`, and the real `calibration_set_id` reaches the QRMI result record. Both legs agree on counts and normalized shape — the shim's central claim, now shown on hardware rather than a mock.

## Notes for reviewers

- **Nothing pins iqm-client.** The container installs `iqm-qdmi[qiskit]` and takes whatever iqm-client arrives transitively, so breakage #1 recurs silently on any rebuild. Worth a pin or a recorded known-good version.
- Two further issues found in the same session are **not** addressed here and may deserve their own tickets: QFw's PRTE launcher does not propagate `QFW_QC_URL`/`QFW_API_KEY` across its `ssh` to the compute node (so the DEFw service silently falls back to `dev-config`, making TESTING.md's Tier 2 instructions wrong for execution); and QRMI's `target()` swallows per-field fetch errors, returning the key skeleton with empty values, which surfaces a connection failure as "IQM dynamic architecture did not report active qubits".
- The QDMI result record omits `calibration.id` and `job.id`, which QRMI provides. The missing job id means a QDMI run cannot be correlated with the IQM-side job — relevant for scheduler accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
