### PR TITLE
QFw: read the QDMI job id as a property, not a method

### DIFF
--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -218,8 +218,16 @@ class QdmiDriver(BaseDriver):
 		timing["wait_seconds"] = (
 			time.monotonic() - start - timing["submit_seconds"])
 		try:
-			job_id = job.id()
-		except Exception:
+			# FoMaC exposes QDMI_JOB_PROPERTY_ID as a PROPERTY, not a method.
+			# Calling it raised TypeError, which the except below then swallowed,
+			# so job_id was always None and every QDMI result record lost the
+			# provider job id -- leaving QDMI runs uncorrelatable with the
+			# IQM-side job. QDMI-on-IQM does populate the property.
+			job_id = job.id
+		except Exception as exc:
+			# A device need not implement QDMI_JOB_PROPERTY_ID; carry on without
+			# it, but leave a trace rather than dropping it silently.
+			logging.debug("shim: QDMI job id unavailable: %s", exc)
 			job_id = None
 		if status != "completed":
 			self._last_job = {


### PR DESCRIPTION
Every QDMI-path result record was losing the provider job id, so a QDMI run could not be correlated with the IQM-side job afterwards. That matters for scheduler accounting and incident forensics on a shared instrument.

## Cause

FoMaC exposes `QDMI_JOB_PROPERTY_ID` as a **property** on the `Job` object. `qdmi_driver.run_circuit` called it as a method:

```python
try:
    job_id = job.id()      # TypeError: property value is not callable
except Exception:
    job_id = None          # ... swallowed here
```

The bare `except` absorbed the `TypeError`, so `job_id` was always `None` and the failure was invisible.

## The property is populated end to end

This was not a missing capability at any layer:

- QDMI defines `QDMI_JOB_PROPERTY_ID`
- QDMI-on-IQM answers it with the IQM job id — `src/iqm_device.cpp`, `QDMI_DEVICE_JOB_PROPERTY_ID` → `job->job_id_`
- MQT Core FoMaC exposes it as `Job.id`

Only the caller was wrong.

## Fix

Access it as a property. The fallback stays — a device need not implement the property — but it now logs when taken, since the silence is what hid this in the first place.

## Observed

On the ORNL IQM q20, running the same circuit through each library: QRMI-path records carried `job.id` and `job.provider_status`; QDMI-path records reported only `job: {status: completed}`.

Verified the property access is correct against the installed `mqt-core` 3.7.0 (`isinstance(fomac.Job.__dict__["id"], property)` is `True`). **Not** re-run against hardware — worth confirming a QDMI-path record now carries the id on the next live run.
