### PR TITLE
QFw: measure execution cost, and add a native-client baseline

### DIFF
--- a/examples/measure_shim_execution.py
+++ b/examples/measure_shim_execution.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+"""Measure where time goes executing a circuit through QRMI vs QDMI.
+
+USES QPU TIME. Unlike measure_shim_introspection.py this submits real circuits
+to the device, one per library per repeat. Defaults are deliberately small: a
+single-qubit circuit at 10 shots, one repeat.
+
+The question is whether the envelope-assembly difference between the two
+libraries costs anything measurable. QRMI's caller builds the entire IQM run
+request -- circuits, shots, calibration set -- and submits it as one opaque
+provider document. QDMI's caller submits a single circuit and the device
+implementation assembles the surrounding request itself, with shots passed as a
+typed job parameter. So the same execution is split differently between caller
+and library, and this measures that split.
+
+Phases per run:
+
+  prep      client-side preparation before the provider is contacted:
+            transcoding OpenQASM to an IQM circuit, and building the payload
+            (a RunRequest for QRMI, a serialized single circuit for QDMI).
+            Derived, since the drivers begin their own clock at submit.
+  submit    handing the job to the provider
+  wait      polling until the job reaches a terminal state
+  fetch     retrieving the results
+  total     measured around the whole run_circuit call
+
+Connections opened during the run are counted as well. That matters here for
+the same reason it did for introspection: a client that reconnects per request
+pays a TLS handshake every time, and execution polls repeatedly, so a
+per-request reconnect is multiplied by the poll count rather than paid once.
+
+The drivers are opened and warmed before timing, so this measures execution and
+not session setup -- see measure_shim_introspection.py for that.
+
+Run it inside the container, with device access configured:
+
+  docker exec c5 bash -c 'source /opt/qfw/qhpc/QFw/setup/qfw_activate \\
+      >/dev/null 2>&1 && source "$QFW_IMAGE_VENV/bin/activate" \\
+      && python -u /opt/qfw/qhpc/QFw/examples/measure_shim_execution.py'
+"""
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from measurement_support import (  # noqa: E402
+	ConnectionSampler, MeasurementError, driver_for, endpoint_context,
+	endpoint_port, fmt_ms, require_counts, require_qubits)
+
+# One qubit, flipped and measured: the smallest circuit that still exercises
+# transcoding, submission, and a non-trivial result. Expect counts to be all
+# "1" apart from readout error.
+SMOKE_QASM = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[1];
+creg c[1];
+x q[0];
+measure q[0] -> c[0];
+"""
+
+
+class _Circuit:
+	"""Minimal duck-typed circuit: what the drivers read off a QFw job.
+
+	Both drivers take `circuit.info["qasm"]` plus execution options, and an
+	optional get_cid(). Constructing one here keeps DEFw RPC out of the
+	measurement, the same way the introspection script bypasses the service.
+	"""
+
+	def __init__(self, qasm, shots, timeout, poll_interval):
+		self._cid = str(uuid.uuid4())
+		self.info = {
+			"qasm": qasm,
+			"num_shots": int(shots),
+			"timeout": float(timeout),
+			"poll_interval": float(poll_interval),
+			"cid": self._cid,
+		}
+
+	def get_cid(self):
+		return self._cid
+
+
+def _warm(library, driver):
+	"""Open the handle and pay every first-call cost before timing starts.
+
+	Two things are warmed. The driver's own handle and cache, so a run is not
+	charged for session setup. And the transcoder, because build_iqm_circuit()
+	imports Qiskit and iqm.qiskit_iqm lazily on first use: without this the
+	first library measured is charged roughly 3.4 seconds of module import and
+	appears to have ~57x the payload-assembly cost of the second. That is an
+	ordering artifact, confirmed by reversing the library order and watching
+	the penalty follow position rather than library.
+	"""
+	if library == "qrmi":
+		driver._qpu()
+	else:
+		driver._device()
+
+	device_info = driver.get_device_info()
+	require_qubits(device_info)
+
+	from util.iqm_transcode import build_iqm_circuit
+	qubits = [q["id"] for q in device_info.get("qubits", []) if q.get("id")]
+	# Same call the drivers make, against the same dynamic-architecture shape.
+	build_iqm_circuit(SMOKE_QASM, {"qubits": qubits}, None)
+
+
+def measure_library(library, device_id, args, count_port=None):
+	from svc_lib_qpm.descriptor import resolve_descriptor
+
+	descriptor = resolve_descriptor(device_id)
+	driver = driver_for(library, descriptor)
+
+	warm_start = time.perf_counter()
+	_warm(library, driver)
+	warm_seconds = time.perf_counter() - warm_start
+
+	runs = []
+	for _ in range(args.repeat):
+		circuit = _Circuit(SMOKE_QASM, args.shots, args.circuit_timeout,
+				args.poll_interval)
+		with ConnectionSampler(count_port,
+				enabled=count_port is not None) as conns:
+			started = time.perf_counter()
+			record = driver.run_circuit(circuit)
+			total = time.perf_counter() - started
+
+		counts = require_counts(record)
+
+		# The drivers time submit/wait/fetch from their own clock, started just
+		# before submission. Anything before that -- transcode and payload
+		# assembly -- is the difference against the total measured here.
+		driver_timing = (driver.get_last_job_timing() or {}).get("timing") or {}
+		submit = driver_timing.get("submit_seconds")
+		wait = driver_timing.get("wait_seconds")
+		fetch = driver_timing.get("result_fetch_seconds")
+		accounted = sum(v for v in (submit, wait, fetch) if v is not None)
+
+		runs.append({
+			"total_seconds": total,
+			"prep_seconds": max(total - accounted, 0.0),
+			"submit_seconds": submit,
+			"wait_seconds": wait,
+			"result_fetch_seconds": fetch,
+			"driver_total_wall_seconds": driver_timing.get(
+					"total_wall_seconds"),
+			"connections": len(conns.endpoints) if conns.supported else None,
+			"counts": counts,
+			"shots": args.shots,
+		})
+
+	return {
+		"library": library,
+		"device_id": device_id,
+		"warm_seconds": warm_seconds,
+		"runs": runs,
+	}
+
+
+def _median(runs, key):
+	values = [r[key] for r in runs if r.get(key) is not None]
+	return statistics.median(values) if values else None
+
+
+def render(record):
+	context = record.get("context", {})
+	print("QFw shim execution cost -- QRMI vs QDMI")
+	print(f"  endpoint      {context.get('base_url', 'unknown')}")
+	print(f"  host          {record.get('host', 'unknown')}")
+	print(f"  circuit       1 qubit, x + measure, {record.get('shots')} shots")
+	print(f"  repeats       {record.get('repeat')} per library")
+	print()
+
+	counting = record.get("connection_counting", {}).get("supported")
+	header = (f"  {'library':<8} {'prep':>11} {'submit':>11} {'wait':>11}"
+			f" {'fetch':>11} {'total':>11}")
+	if counting:
+		header += f" {'conns':>7}"
+	print("PER RUN (median)")
+	print(header)
+
+	for library, entry in record.get("libraries", {}).items():
+		if "error" in entry:
+			print(f"  {library:<8} unavailable: {entry['error']}")
+			continue
+		runs = entry["runs"]
+		row = (f"  {library:<8} {fmt_ms(_median(runs, 'prep_seconds')):>11}"
+				f" {fmt_ms(_median(runs, 'submit_seconds')):>11}"
+				f" {fmt_ms(_median(runs, 'wait_seconds')):>11}"
+				f" {fmt_ms(_median(runs, 'result_fetch_seconds')):>11}"
+				f" {fmt_ms(_median(runs, 'total_seconds')):>11}")
+		if counting:
+			conns = _median(runs, "connections")
+			row += f" {conns:>7.0f}" if conns is not None else f" {'n/a':>7}"
+		print(row)
+	print()
+	print("  prep    = transcode + payload assembly, before the provider is")
+	print("            contacted. Derived: total minus submit/wait/fetch.")
+	print("  wait    = polling to terminal; includes device queue time, which")
+	print("            neither interface reports separately.")
+	if counting:
+		print("  conns   = TCP connections opened during the run. Execution")
+		print("            polls, so a per-request reconnect multiplies.")
+	print()
+	for library, entry in record.get("libraries", {}).items():
+		if "error" not in entry and entry["runs"]:
+			print(f"  {library}: counts {entry['runs'][0]['counts']}")
+
+
+def parse_args():
+	parser = argparse.ArgumentParser(
+		description="Measure QRMI vs QDMI circuit-execution cost. USES QPU TIME.")
+	parser.add_argument("--device-id", default="ornl-iqm-20q")
+	parser.add_argument("--libraries", default="qrmi,qdmi")
+	parser.add_argument(
+		"--shots", type=int, default=10,
+		help="Shots per circuit. Kept small: this runs on real hardware.")
+	parser.add_argument(
+		"--repeat", type=int, default=1,
+		help="Circuits per library. Each one consumes QPU time.")
+	parser.add_argument("--circuit-timeout", type=float, default=600.0)
+	parser.add_argument("--poll-interval", type=float, default=1.0)
+	parser.add_argument(
+		"--count-connections", action="store_true",
+		help="Also count TCP connections opened per run (Linux only).")
+	parser.add_argument("--json", action="store_true")
+	args = parser.parse_args()
+	args.libraries = [x.strip() for x in args.libraries.split(",") if x.strip()]
+	return args
+
+
+def main():
+	args = parse_args()
+	context = endpoint_context(args.device_id)
+	count_port = endpoint_port(context) if args.count_connections else None
+
+	record = {
+		"schema": "qfw-execution-measurement-v0",
+		"timestamp": datetime.now(timezone.utc).isoformat(),
+		"host": os.uname().nodename,
+		"shots": args.shots,
+		"repeat": args.repeat,
+		"context": context,
+		"connection_counting": {
+			"requested": bool(args.count_connections),
+			"port": count_port,
+			"supported": bool(count_port) and sys.platform.startswith("linux"),
+		},
+		"libraries": {},
+	}
+
+	failed = False
+	for library in args.libraries:
+		try:
+			record["libraries"][library] = measure_library(
+					library, args.device_id, args, count_port=count_port)
+		except Exception as exc:
+			record["libraries"][library] = {
+				"library": library,
+				"error": f"{type(exc).__name__}: {exc}",
+			}
+			failed = True
+
+	if args.json:
+		print(json.dumps(record, indent=2))
+	else:
+		render(record)
+	return 1 if failed else 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/examples/measure_shim_execution.py
+++ b/examples/measure_shim_execution.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
-"""Measure where time goes executing a circuit through QRMI vs QDMI.
+"""Measure where time goes executing a circuit: QRMI vs QDMI vs native.
 
 USES QPU TIME. Unlike measure_shim_introspection.py this submits real circuits
-to the device, one per library per repeat. Defaults are deliberately small: a
+to the device, one per path per repeat. Defaults are deliberately small: a
 single-qubit circuit at 10 shots, one repeat.
+
+Three paths are compared: the two shim libraries, and QFw's native IQM service
+client (svc_iqm_qpm), which talks to iqm-client directly. The native arm is the
+baseline the interface-convergence question needs -- it shows what the shim
+layers cost, and what they save.
 
 The question is whether the envelope-assembly difference between the two
 libraries costs anything measurable. QRMI's caller builds the entire IQM run
@@ -52,7 +57,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from measurement_support import (  # noqa: E402
 	ConnectionSampler, MeasurementError, driver_for, endpoint_context,
-	endpoint_port, fmt_ms, require_counts, require_qubits)
+	endpoint_port, fmt_ms, open_handle, require_counts, require_qubits)
 
 # One qubit, flipped and measured: the smallest circuit that still exercises
 # transcoding, submission, and a non-trivial result. Expect counts to be all
@@ -99,10 +104,7 @@ def _warm(library, driver):
 	ordering artifact, confirmed by reversing the library order and watching
 	the penalty follow position rather than library.
 	"""
-	if library == "qrmi":
-		driver._qpu()
-	else:
-		driver._device()
+	open_handle(library, driver)
 
 	device_info = driver.get_device_info()
 	require_qubits(device_info)
@@ -153,6 +155,12 @@ def measure_library(library, device_id, args, count_port=None):
 			"driver_total_wall_seconds": driver_timing.get(
 					"total_wall_seconds"),
 			"connections": len(conns.endpoints) if conns.supported else None,
+			# Provider-reported phase durations, where the path exposes any.
+			# Only the native client does: it reads the IQM job timeline, so it
+			# can separate queue wait from execution. Neither QRMI nor QDMI
+			# passes that through, which is why this is None for them.
+			"provider_durations": (driver.provider_durations()
+					if hasattr(driver, "provider_durations") else None),
 			"counts": counts,
 			"shots": args.shots,
 		})
@@ -172,7 +180,7 @@ def _median(runs, key):
 
 def render(record):
 	context = record.get("context", {})
-	print("QFw shim execution cost -- QRMI vs QDMI")
+	print("QFw execution cost -- QRMI vs QDMI vs native IQM client")
 	print(f"  endpoint      {context.get('base_url', 'unknown')}")
 	print(f"  host          {record.get('host', 'unknown')}")
 	print(f"  circuit       1 qubit, x + measure, {record.get('shots')} shots")
@@ -202,8 +210,11 @@ def render(record):
 			row += f" {conns:>7.0f}" if conns is not None else f" {'n/a':>7}"
 		print(row)
 	print()
-	print("  prep    = transcode + payload assembly, before the provider is")
-	print("            contacted. Derived: total minus submit/wait/fetch.")
+	print("  prep    = everything before submit: transcode + payload assembly.")
+	print("            Derived as total minus submit/wait/fetch. For the shim")
+	print("            drivers this is local work; the native path also")
+	print("            re-fetches the dynamic architecture here, having no")
+	print("            introspection cache, so its prep includes a round trip.")
 	print("  wait    = polling to terminal; includes device queue time, which")
 	print("            neither interface reports separately.")
 	if counting:
@@ -214,12 +225,32 @@ def render(record):
 		if "error" not in entry and entry["runs"]:
 			print(f"  {library}: counts {entry['runs'][0]['counts']}")
 
+	# Provider-reported phase durations. The point of showing these is which
+	# paths have none: queue wait and execution are separable only where the
+	# provider's own timeline survives to the caller.
+	print()
+	print("PROVIDER-REPORTED TIMING (from the device's job timeline)")
+	for library, entry in record.get("libraries", {}).items():
+		if "error" in entry or not entry["runs"]:
+			continue
+		durations = entry["runs"][0].get("provider_durations")
+		if not durations:
+			print(f"  {library:<8} none - this path does not surface the "
+					"provider's timeline")
+			continue
+		queue = durations.get("queue_wait_received_to_validation_started")
+		execution = durations.get("execution")
+		total = durations.get("server_total_created_to_completed")
+		print(f"  {library:<8} queue {fmt_ms(queue)}"
+				f"   execution {fmt_ms(execution)}"
+				f"   server total {fmt_ms(total)}")
+
 
 def parse_args():
 	parser = argparse.ArgumentParser(
-		description="Measure QRMI vs QDMI circuit-execution cost. USES QPU TIME.")
+		description="Measure QRMI vs QDMI vs native circuit-execution cost. USES QPU TIME.")
 	parser.add_argument("--device-id", default="ornl-iqm-20q")
-	parser.add_argument("--libraries", default="qrmi,qdmi")
+	parser.add_argument("--libraries", default="qrmi,qdmi,native")
 	parser.add_argument(
 		"--shots", type=int, default=10,
 		help="Shots per circuit. Kept small: this runs on real hardware.")

--- a/examples/measure_shim_introspection.py
+++ b/examples/measure_shim_introspection.py
@@ -51,208 +51,16 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timezone
-from urllib.parse import urlsplit
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from measurement_support import (  # noqa: E402
+	ConnectionSampler, driver_for, endpoint_context,
+	endpoint_port, fmt_ms, require_qubits)
 
 # Introspection calls served by both libraries, so the same set can be timed on
 # each. Kept in a fixed order because the first one is the cold-path call.
 CALLS = ("get_device_info", "get_coupling_graph", "get_calibration_snapshot")
-
-
-class MeasurementError(Exception):
-	"""A sample was taken but cannot be trusted."""
-
-
-# --- connection counting ------------------------------------------------
-#
-# How many TCP connections a library opens to reach the same data is the
-# difference that explains most of the cold-cost gap: a client that pools and
-# reuses one connection pays one TLS handshake, one that opens a fresh
-# connection per request pays a handshake every time. Over a tunnel a handshake
-# costs about as much as a request, so this is worth counting rather than
-# inferring from timings.
-#
-# Counted by sampling /proc for this process's own sockets whose remote port is
-# the endpoint's, and accumulating distinct local endpoints. Filtering by our
-# own socket inodes keeps other processes on the node out of the count.
-#
-# Limits: Linux only, and a poll can miss a connection shorter-lived than the
-# sample interval, so the count is a lower bound. Off by default because the
-# sampler runs concurrently with the timed calls.
-
-
-# The sampler runs in a SUBPROCESS, not a thread. QDMI's session init is a
-# single blocking call into the C++ device library which holds the GIL for its
-# whole duration, so an in-process Python sampler is frozen exactly when the
-# connections it should be counting are being opened -- it reported zero for
-# QDMI while `ss` showed five. A separate process is not subject to the GIL.
-_SAMPLER_SOURCE = r'''
-import os, sys, time
-
-pid, port, interval = int(sys.argv[1]), int(sys.argv[2]), float(sys.argv[3])
-out_path, stop_path = sys.argv[4], sys.argv[5]
-seen = set()
-
-# Backstop lifetime. A phase takes seconds; this only bounds a sampler whose
-# parent vanished between the liveness checks below.
-MAX_LIFETIME = 300.0
-started = time.monotonic()
-
-def socket_inodes():
-    found = set()
-    try:
-        fds = os.listdir("/proc/%d/fd" % pid)
-    except OSError:
-        return found
-    for fd in fds:
-        try:
-            target = os.readlink("/proc/%d/fd/%s" % (pid, fd))
-        except OSError:
-            continue
-        if target.startswith("socket:["):
-            found.add(target[8:-1])
-    return found
-
-def peers():
-    for path in ("/proc/net/tcp", "/proc/net/tcp6"):
-        try:
-            with open(path) as stream:
-                next(stream, None)
-                for line in stream:
-                    fields = line.split()
-                    if len(fields) < 10:
-                        continue
-                    try:
-                        if int(fields[2].rsplit(":", 1)[1], 16) != port:
-                            continue
-                    except (IndexError, ValueError):
-                        continue
-                    yield fields[1], fields[9]
-        except OSError:
-            continue
-
-# Results go to a file and shutdown is signalled by a file, not by pipes and
-# signals: kill()+communicate() proved unreliable in the container this runs in
-# (a trivial child reproduced the same hang), and a sampler that cannot be
-# stopped or read is worse than no sampler.
-with open(out_path, "a", buffering=1) as sink:
-    while not os.path.exists(stop_path):
-        # Never outlive the parent. Without these two guards a parent that dies
-        # without running its cleanup -- killed, crashed, interrupted -- leaves
-        # this process polling forever. socket_inodes() fails softly when the
-        # parent is gone, so the loop would spin rather than error out. During
-        # development that left 21 orphaned samplers burning 145% CPU.
-        if not os.path.isdir("/proc/%d" % pid):
-            break
-        if time.monotonic() - started > MAX_LIFETIME:
-            break
-        ours = socket_inodes()
-        for local, inode in peers():
-            if inode in ours and local not in seen:
-                seen.add(local)
-                sink.write(local + "\n")   # line-buffered, so already flushed
-        time.sleep(interval)
-'''
-
-
-class ConnectionSampler:
-	"""Count distinct TCP connections this process opens to a port.
-
-	Use as a context manager; `endpoints` holds the local endpoints observed.
-	Counting *new* connections for a later phase means differencing against an
-	earlier phase's set -- a pooled connection stays open and visible, so
-	observing it again is not the same as opening it again.
-	"""
-
-	def __init__(self, port, interval=0.02, enabled=True):
-		self._port = port
-		self._interval = interval
-		self._enabled = bool(enabled and sys.platform.startswith("linux")
-				and port)
-		self._proc = None
-		self._dir = None
-		self.endpoints = set()
-
-	@property
-	def supported(self):
-		return self._enabled
-
-	def __enter__(self):
-		if not self._enabled:
-			return self
-		import tempfile
-		self._dir = tempfile.mkdtemp(prefix="qfw-connsample-")
-		self._out = os.path.join(self._dir, "endpoints")
-		self._stop = os.path.join(self._dir, "stop")
-		open(self._out, "w").close()
-		try:
-			self._proc = subprocess.Popen(
-				[sys.executable, "-c", _SAMPLER_SOURCE,
-					str(os.getpid()), str(self._port), str(self._interval),
-					self._out, self._stop],
-				stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-		except OSError:
-			self._proc = None
-			self._enabled = False
-		return self
-
-	def __exit__(self, *exc):
-		if self._proc is None:
-			return False
-		open(self._stop, "w").close()
-		# Give the sampler a couple of poll intervals to notice and exit.
-		deadline = time.monotonic() + max(1.0, self._interval * 10)
-		while time.monotonic() < deadline and self._proc.poll() is None:
-			time.sleep(self._interval)
-		if self._proc.poll() is None:
-			self._proc.kill()
-		try:
-			with open(self._out, "r", encoding="utf-8") as stream:
-				self.endpoints = {line.strip() for line in stream
-						if line.strip()}
-		except OSError:
-			self.endpoints = set()
-		import shutil
-		shutil.rmtree(self._dir, ignore_errors=True)
-		return False
-
-
-def _qubit_count(record):
-	# Qubit count from a qhw-device-v1 record, or None if this is not one.
-	if isinstance(record, dict) and isinstance(record.get("qubits"), list):
-		return len(record["qubits"])
-	return None
-
-
-def _require_real_payload(record):
-	# A timing is only meaningful if the call actually returned device data.
-	#
-	# This check exists because QRMI's target() does not raise when its REST
-	# fetches fail: each field is individually guarded and replaced with null,
-	# so an unreachable endpoint yields a successful call returning an empty
-	# document. Timing that path produces plausible-looking numbers -- observed
-	# at ~45 ms cold against a dead endpoint -- that measure nothing but the
-	# speed of failing. Worse, they flatter QRMI relative to QDMI, which raises
-	# on a failed session init and so reports no sample at all.
-	#
-	# Requiring a non-empty qubit list turns that silent case into a loud one.
-	qubits = _qubit_count(record)
-	if not qubits:
-		raise MeasurementError(
-			"introspection returned no qubits, so this sample is not a "
-			"measurement of a working call. The endpoint is most likely "
-			"unreachable; note that QRMI reports this as success with null "
-			"fields rather than raising.")
-	return qubits
-
-
-def _driver(library, descriptor):
-	from svc_lib_qpm.drivers import QdmiDriver, QrmiDriver
-
-	if library == "qrmi":
-		return QrmiDriver(descriptor)
-	if library == "qdmi":
-		return QdmiDriver(descriptor)
-	raise ValueError(f"unknown library {library!r}")
 
 
 def _open_handle(library, driver):
@@ -272,7 +80,7 @@ def measure_library(library, device_id, warm_iterations, count_port=None):
 	result = {"library": library, "device_id": device_id}
 
 	construct_start = time.perf_counter()
-	driver = _driver(library, descriptor)
+	driver = driver_for(library, descriptor)
 	result["construct_seconds"] = time.perf_counter() - construct_start
 
 	# Cold phase: open + first call, with connections counted across both,
@@ -287,7 +95,7 @@ def measure_library(library, device_id, warm_iterations, count_port=None):
 		result["first_call_seconds"] = time.perf_counter() - first_start
 
 	# Validate before reporting: a fast failure must not read as a fast call.
-	result["qubits_seen"] = _require_real_payload(first_record)
+	result["qubits_seen"] = require_qubits(first_record)
 	result["cold_seconds"] = result["open_seconds"] + result["first_call_seconds"]
 	result["cold_connections"] = (
 			len(cold_conns.endpoints) if cold_conns.supported else None)
@@ -303,7 +111,7 @@ def measure_library(library, device_id, warm_iterations, count_port=None):
 				returned = getattr(driver, call)()
 				samples.append(time.perf_counter() - start)
 				if call == "get_device_info":
-					_require_real_payload(returned)
+					require_qubits(returned)
 			warm[call] = {
 				"samples": samples,
 				"median_seconds": statistics.median(samples) if samples else None,
@@ -319,35 +127,9 @@ def measure_library(library, device_id, warm_iterations, count_port=None):
 	return result
 
 
-def endpoint_context(device_id):
-	"""Endpoint identity for the record. Never returns the token."""
-	try:
-		from svc_lib_qpm.descriptor import resolve_descriptor
-		from svc_lib_qpm.drivers import QrmiDriver
-
-		access = QrmiDriver(resolve_descriptor(device_id))._access()
-		return {
-			"base_url": access.get("base_url"),
-			"provider_device_id": access.get("provider_device_id"),
-		}
-	except Exception as exc:
-		return {"error": f"{type(exc).__name__}: {exc}"}
-
-
-def _endpoint_port(context):
-	# Port the libraries connect to, for connection counting.
-	base_url = (context or {}).get("base_url")
-	if not base_url:
-		return None
-	parts = urlsplit(base_url)
-	if parts.port:
-		return parts.port
-	return 443 if parts.scheme == "https" else 80
-
-
 def run_once(args):
 	context = endpoint_context(args.device_id)
-	count_port = _endpoint_port(context) if args.count_connections else None
+	count_port = endpoint_port(context) if args.count_connections else None
 	record = {
 		"schema": "qfw-introspection-measurement-v0",
 		"timestamp": datetime.now(timezone.utc).isoformat(),
@@ -402,9 +184,6 @@ def run_repeated(args):
 	return records
 
 
-def _fmt(seconds):
-	return f"{seconds * 1000:.1f} ms"
-
 
 def render(records):
 	first = records[0]
@@ -448,9 +227,9 @@ def render(records):
 			error = first["libraries"].get(library, {}).get("error", "no data")
 			print(f"  {library:<8} unavailable: {error}")
 			continue
-		row = (f"  {library:<8} {_fmt(statistics.median(opens)):>12}"
-				f" {_fmt(statistics.median(firsts)):>12}"
-				f" {_fmt(statistics.median(colds)):>12}")
+		row = (f"  {library:<8} {fmt_ms(statistics.median(opens)):>12}"
+				f" {fmt_ms(statistics.median(firsts)):>12}"
+				f" {fmt_ms(statistics.median(colds)):>12}")
 		if counting:
 			row += f" {(statistics.median(conns) if conns else 0):>7.0f}"
 		print(row)
@@ -473,7 +252,7 @@ def render(records):
 				warm = entry.get("warm", {}).get(call)
 				if warm:
 					samples.extend(warm["samples"])
-			cells.append(_fmt(statistics.median(samples)) if samples else "n/a")
+			cells.append(fmt_ms(statistics.median(samples)) if samples else "n/a")
 		row = f"  {library:<8}" + "".join(f"{c:>26}" for c in cells)
 		if counting:
 			warm_conns = [record["libraries"].get(library, {}).get("warm_connections")

--- a/examples/measure_shim_introspection.py
+++ b/examples/measure_shim_introspection.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Measure QRMI vs QDMI device-introspection cost, cold and warm.
+"""Measure device-introspection cost, cold and warm: QRMI, QDMI, native.
 
 Read-only: this submits no circuits and consumes no QPU time.
 
@@ -14,6 +14,10 @@ cost lands in different places:
   QDMI   opening the device (FoMaC add_dynamic_device_library) initializes a
          session, and the IQM device library fetches its data during that init.
          The network cost is paid at OPEN; later property queries are local.
+
+  native QFw's own svc_iqm_qpm client, talking to iqm-client directly. It holds
+         no introspection cache at all, so every call re-fetches -- which is
+         what the warm column exposes.
 
 So a fair comparison has to separate opening from querying, otherwise QRMI
 looks slow at the first call and QDMI looks slow at startup while both are
@@ -56,20 +60,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from measurement_support import (  # noqa: E402
 	ConnectionSampler, driver_for, endpoint_context,
-	endpoint_port, fmt_ms, require_qubits)
+	endpoint_port, fmt_ms, open_handle, require_qubits)
 
 # Introspection calls served by both libraries, so the same set can be timed on
 # each. Kept in a fixed order because the first one is the cold-path call.
 CALLS = ("get_device_info", "get_coupling_graph", "get_calibration_snapshot")
-
-
-def _open_handle(library, driver):
-	# Force the lazy handle without issuing an introspection call, so the open
-	# cost is attributed separately from the first query. These are the private
-	# accessors the drivers use internally; there is no public "open" call.
-	if library == "qrmi":
-		return driver._qpu()
-	return driver._device()
 
 
 def measure_library(library, device_id, warm_iterations, count_port=None):
@@ -87,7 +82,7 @@ def measure_library(library, device_id, warm_iterations, count_port=None):
 	# since the libraries do their fetching in different phases.
 	with ConnectionSampler(count_port, enabled=count_port is not None) as cold_conns:
 		open_start = time.perf_counter()
-		_open_handle(library, driver)
+		open_handle(library, driver)
 		result["open_seconds"] = time.perf_counter() - open_start
 
 		first_start = time.perf_counter()
@@ -197,7 +192,7 @@ def render(records):
 			break
 	alias = context.get("provider_device_id", "unknown")
 
-	print("QFw shim introspection cost -- QRMI vs QDMI")
+	print("QFw introspection cost -- QRMI vs QDMI vs native IQM client")
 	print(f"  endpoint      {context.get('base_url', 'unknown')}")
 	print(f"  device        {device_id}  (provider alias {alias})")
 	print(f"  host          {first.get('host', 'unknown')}")
@@ -272,12 +267,12 @@ def render(records):
 
 def parse_args():
 	parser = argparse.ArgumentParser(
-		description="Measure QRMI vs QDMI introspection cost (no QPU time).")
+		description="Measure QRMI vs QDMI vs native introspection cost (no QPU time).")
 	parser.add_argument(
 		"--device-id", default="ornl-iqm-20q",
 		help="QFw device id to resolve the descriptor from.")
 	parser.add_argument(
-		"--libraries", default="qrmi,qdmi",
+		"--libraries", default="qrmi,qdmi,native",
 		help="Comma-separated libraries to measure.")
 	parser.add_argument(
 		"--warm-iterations", type=int, default=5,

--- a/examples/measure_shim_introspection.py
+++ b/examples/measure_shim_introspection.py
@@ -92,6 +92,11 @@ pid, port, interval = int(sys.argv[1]), int(sys.argv[2]), float(sys.argv[3])
 out_path, stop_path = sys.argv[4], sys.argv[5]
 seen = set()
 
+# Backstop lifetime. A phase takes seconds; this only bounds a sampler whose
+# parent vanished between the liveness checks below.
+MAX_LIFETIME = 300.0
+started = time.monotonic()
+
 def socket_inodes():
     found = set()
     try:
@@ -131,6 +136,15 @@ def peers():
 # stopped or read is worse than no sampler.
 with open(out_path, "a", buffering=1) as sink:
     while not os.path.exists(stop_path):
+        # Never outlive the parent. Without these two guards a parent that dies
+        # without running its cleanup -- killed, crashed, interrupted -- leaves
+        # this process polling forever. socket_inodes() fails softly when the
+        # parent is gone, so the loop would spin rather than error out. During
+        # development that left 21 orphaned samplers burning 145% CPU.
+        if not os.path.isdir("/proc/%d" % pid):
+            break
+        if time.monotonic() - started > MAX_LIFETIME:
+            break
         ours = socket_inodes()
         for local, inode in peers():
             if inode in ours and local not in seen:

--- a/examples/measurement_support.py
+++ b/examples/measurement_support.py
@@ -1,0 +1,238 @@
+"""Shared helpers for the QRMI/QDMI measurement scripts in this directory.
+
+Kept in one module rather than copied per script: the connection sampler
+manages a subprocess, and that is not code worth maintaining twice.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from urllib.parse import urlsplit
+
+
+class MeasurementError(Exception):
+	"""A sample was taken but cannot be trusted."""
+
+
+# --- payload validation -------------------------------------------------
+#
+# A timing is only meaningful if the call actually did the work. QRMI's
+# target() does not raise when its REST fetches fail -- each field is guarded
+# individually and replaced with null -- so an unreachable endpoint yields a
+# successful call returning an empty document. Timing that path produces
+# plausible-looking numbers that measure nothing but the speed of failing, and
+# flatter QRMI against QDMI, which raises instead. Validate the payload, never
+# just the absence of an exception.
+
+
+def require_qubits(record):
+	"""Qubit count from a qhw device record; raise if it is empty."""
+	qubits = record.get("qubits") if isinstance(record, dict) else None
+	if not isinstance(qubits, list) or not qubits:
+		raise MeasurementError(
+			"introspection returned no qubits, so this sample is not a "
+			"measurement of a working call. The endpoint is most likely "
+			"unreachable; note that QRMI reports this as success with null "
+			"fields rather than raising.")
+	return len(qubits)
+
+
+def require_counts(record):
+	"""Shot counts from a qhw-result-v1 record; raise if the run did not land."""
+	result = record.get("result") if isinstance(record, dict) else None
+	counts = (result or {}).get("counts") if isinstance(result, dict) else None
+	if not counts or not sum(int(v) for v in counts.values()):
+		raise MeasurementError(
+			"execution returned no shot counts, so this sample did not "
+			"measure a completed circuit.")
+	return counts
+
+
+# --- connection counting ------------------------------------------------
+#
+# How many TCP connections a library opens to reach the same data is the
+# difference that explains most of the cold-cost gap: a client that pools and
+# reuses one connection pays one TLS handshake, one that opens a fresh
+# connection per request pays a handshake every time. Over a wide-area path a
+# handshake costs about as much as a request, so this is worth counting rather
+# than inferring from timings.
+#
+# Limits: Linux only, and a poll can miss a connection shorter-lived than the
+# sample interval, so a count is a lower bound.
+
+_SAMPLER_SOURCE = r'''
+import os, sys, time
+
+pid, port, interval = int(sys.argv[1]), int(sys.argv[2]), float(sys.argv[3])
+out_path, stop_path = sys.argv[4], sys.argv[5]
+seen = set()
+
+# Backstop lifetime. A phase takes seconds; this only bounds a sampler whose
+# parent vanished between the liveness checks below.
+MAX_LIFETIME = 300.0
+started = time.monotonic()
+
+def socket_inodes():
+    found = set()
+    try:
+        fds = os.listdir("/proc/%d/fd" % pid)
+    except OSError:
+        return found
+    for fd in fds:
+        try:
+            target = os.readlink("/proc/%d/fd/%s" % (pid, fd))
+        except OSError:
+            continue
+        if target.startswith("socket:["):
+            found.add(target[8:-1])
+    return found
+
+def peers():
+    for path in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            with open(path) as stream:
+                next(stream, None)
+                for line in stream:
+                    fields = line.split()
+                    if len(fields) < 10:
+                        continue
+                    try:
+                        if int(fields[2].rsplit(":", 1)[1], 16) != port:
+                            continue
+                    except (IndexError, ValueError):
+                        continue
+                    yield fields[1], fields[9]
+        except OSError:
+            continue
+
+with open(out_path, "a", buffering=1) as sink:
+    while not os.path.exists(stop_path):
+        # Never outlive the parent. Without these two guards a parent that dies
+        # without running its cleanup -- killed, crashed, interrupted -- leaves
+        # this process polling forever. socket_inodes() fails softly when the
+        # parent is gone, so the loop would spin rather than error out. During
+        # development that left 21 orphaned samplers burning 145% CPU.
+        if not os.path.isdir("/proc/%d" % pid):
+            break
+        if time.monotonic() - started > MAX_LIFETIME:
+            break
+        ours = socket_inodes()
+        for local, inode in peers():
+            if inode in ours and local not in seen:
+                seen.add(local)
+                sink.write(local + "\n")   # line-buffered, so already flushed
+        time.sleep(interval)
+'''
+
+
+class ConnectionSampler:
+	"""Count distinct TCP connections this process opens to a port.
+
+	Use as a context manager; `endpoints` holds the local endpoints observed.
+	Counting *new* connections for a later phase means differencing against an
+	earlier phase's set -- a pooled connection stays open and visible, so
+	observing it again is not the same as opening it again.
+
+	Runs in a subprocess, not a thread: a blocking call into a C extension
+	holds the GIL for its whole duration, and an in-process sampler is then
+	frozen exactly while the connections it should count are being opened.
+
+	Results and shutdown both go through files rather than pipes and signals,
+	because Popen.kill() followed by communicate() hangs in the container this
+	is used in -- reproducible with a trivial child process.
+	"""
+
+	def __init__(self, port, interval=0.02, enabled=True):
+		self._port = port
+		self._interval = interval
+		self._enabled = bool(enabled and sys.platform.startswith("linux")
+				and port)
+		self._proc = None
+		self._dir = None
+		self.endpoints = set()
+
+	@property
+	def supported(self):
+		return self._enabled
+
+	def __enter__(self):
+		if not self._enabled:
+			return self
+		import tempfile
+		self._dir = tempfile.mkdtemp(prefix="qfw-connsample-")
+		self._out = os.path.join(self._dir, "endpoints")
+		self._stop = os.path.join(self._dir, "stop")
+		open(self._out, "w").close()
+		try:
+			self._proc = subprocess.Popen(
+				[sys.executable, "-c", _SAMPLER_SOURCE,
+					str(os.getpid()), str(self._port), str(self._interval),
+					self._out, self._stop],
+				stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+		except OSError:
+			self._proc = None
+			self._enabled = False
+		return self
+
+	def __exit__(self, *exc):
+		if self._proc is None:
+			return False
+		open(self._stop, "w").close()
+		deadline = time.monotonic() + max(1.0, self._interval * 10)
+		while time.monotonic() < deadline and self._proc.poll() is None:
+			time.sleep(self._interval)
+		if self._proc.poll() is None:
+			self._proc.kill()
+		try:
+			with open(self._out, "r", encoding="utf-8") as stream:
+				self.endpoints = {line.strip() for line in stream
+						if line.strip()}
+		except OSError:
+			self.endpoints = set()
+		import shutil
+		shutil.rmtree(self._dir, ignore_errors=True)
+		return False
+
+
+# --- endpoint context ---------------------------------------------------
+
+
+def endpoint_context(device_id):
+	"""Endpoint identity for the record. Never returns the token."""
+	try:
+		from svc_lib_qpm.descriptor import resolve_descriptor
+		from svc_lib_qpm.drivers import QrmiDriver
+
+		access = QrmiDriver(resolve_descriptor(device_id))._access()
+		return {
+			"base_url": access.get("base_url"),
+			"provider_device_id": access.get("provider_device_id"),
+		}
+	except Exception as exc:
+		return {"error": f"{type(exc).__name__}: {exc}"}
+
+
+def endpoint_port(context):
+	"""Port the libraries connect to, for connection counting."""
+	base_url = (context or {}).get("base_url")
+	if not base_url:
+		return None
+	parts = urlsplit(base_url)
+	if parts.port:
+		return parts.port
+	return 443 if parts.scheme == "https" else 80
+
+
+def driver_for(library, descriptor):
+	from svc_lib_qpm.drivers import QdmiDriver, QrmiDriver
+
+	if library == "qrmi":
+		return QrmiDriver(descriptor)
+	if library == "qdmi":
+		return QdmiDriver(descriptor)
+	raise ValueError(f"unknown library {library!r}")
+
+
+def fmt_ms(seconds):
+	return "n/a" if seconds is None else f"{seconds * 1000:.1f} ms"

--- a/examples/measurement_support.py
+++ b/examples/measurement_support.py
@@ -224,6 +224,69 @@ def endpoint_port(context):
 	return 443 if parts.scheme == "https" else 80
 
 
+class NativeAdapter:
+	"""QFw's native IQM path, presented with the same surface as the drivers.
+
+	`svc_iqm_qpm.util_iqm.IQMServiceClient` already exposes get_device_info,
+	get_coupling_graph, get_calibration_snapshot, run_circuit and
+	get_last_job_timing. Two return shapes differ, so they are adapted here
+	rather than by touching the native service, which is deliberately
+	unmodified by the shim work:
+
+	  run_circuit          returns {"counts", "qhw_result"}; the drivers return
+	                       the qhw record directly.
+	  get_last_job_timing  returns an iqm-timing-summary-v1 record whose
+	                       client-side spans live under "client_wall_seconds".
+
+	That second difference is worth more than the adaptation. The native record
+	also carries `durations_seconds`, derived from the IQM job timeline:
+	queue wait, validation, compilation, execution, post-processing. That is
+	provider-side timing which neither QRMI nor QDMI passes through, so the
+	native arm shows the information exists and is lost at the interface rather
+	than absent at the provider. `provider_durations()` exposes it.
+	"""
+
+	name = "native"
+
+	def __init__(self):
+		from svc_iqm_qpm.util_iqm import IQMServiceClient
+		self._client = IQMServiceClient()
+		self._last_summary = None
+
+	def open(self):
+		return self._client.client()
+
+	def get_device_info(self):
+		return self._client.get_device_info()
+
+	def get_coupling_graph(self, calibration_set_id=None):
+		return self._client.get_coupling_graph(calibration_set_id)
+
+	def get_calibration_snapshot(self, calibration_set_id=None):
+		return self._client.get_calibration_snapshot(calibration_set_id)
+
+	def run_circuit(self, circuit):
+		out = self._client.run_circuit(circuit)
+		if isinstance(out, dict) and "qhw_result" in out:
+			return out["qhw_result"]
+		return out
+
+	def get_last_job_timing(self, cid=None):
+		summary = self._client.get_last_job_timing(cid) or {}
+		self._last_summary = summary
+		wall = summary.get("client_wall_seconds") or {}
+		return {"timing": {
+			"submit_seconds": wall.get("submit"),
+			"wait_seconds": wall.get("wait"),
+			"result_fetch_seconds": wall.get("result_fetch"),
+			"total_wall_seconds": wall.get("total"),
+		}}
+
+	def provider_durations(self):
+		"""Provider-reported phase durations, or None if this path has none."""
+		return (self._last_summary or {}).get("durations_seconds")
+
+
 def driver_for(library, descriptor):
 	from svc_lib_qpm.drivers import QdmiDriver, QrmiDriver
 
@@ -231,7 +294,18 @@ def driver_for(library, descriptor):
 		return QrmiDriver(descriptor)
 	if library == "qdmi":
 		return QdmiDriver(descriptor)
+	if library == "native":
+		return NativeAdapter()
 	raise ValueError(f"unknown library {library!r}")
+
+
+def open_handle(library, driver):
+	"""Force the lazy handle without issuing a call, so open is timed apart."""
+	if library == "qrmi":
+		return driver._qpu()
+	if library == "qdmi":
+		return driver._device()
+	return driver.open()
 
 
 def fmt_ms(seconds):

--- a/examples/measurements/2026-08-04-execution-phases.json
+++ b/examples/measurements/2026-08-04-execution-phases.json
@@ -1,0 +1,85 @@
+{
+  "schema": "qfw-execution-measurement-v0",
+  "timestamp": "2026-08-05T18:16:40.918352+00:00",
+  "host": "c5",
+  "shots": 10,
+  "repeat": 2,
+  "context": {
+    "base_url": "https://qccsw.ccs.ornl.gov:8443",
+    "provider_device_id": "default"
+  },
+  "connection_counting": {
+    "requested": true,
+    "port": 8443,
+    "supported": true
+  },
+  "libraries": {
+    "qrmi": {
+      "library": "qrmi",
+      "device_id": "ornl-iqm-20q",
+      "warm_seconds": 5.10478937800508,
+      "runs": [
+        {
+          "total_seconds": 1.164964166993741,
+          "prep_seconds": 0.06641958202817477,
+          "submit_seconds": 0.14032137498725206,
+          "wait_seconds": 0.6528262509964406,
+          "result_fetch_seconds": 0.30539695898187347,
+          "driver_total_wall_seconds": 1.0985552509955596,
+          "connections": 1,
+          "counts": {
+            "1": 10
+          },
+          "shots": 10
+        },
+        {
+          "total_seconds": 1.0165807919984218,
+          "prep_seconds": 0.06895666601485573,
+          "submit_seconds": 0.12586091700359248,
+          "wait_seconds": 0.5270201669773087,
+          "result_fetch_seconds": 0.2947430420026649,
+          "driver_total_wall_seconds": 0.9476394589873962,
+          "connections": 1,
+          "counts": {
+            "1": 10
+          },
+          "shots": 10
+        }
+      ]
+    },
+    "qdmi": {
+      "library": "qdmi",
+      "device_id": "ornl-iqm-20q",
+      "warm_seconds": 2.6587965009966865,
+      "runs": [
+        {
+          "total_seconds": 2.9898956249817275,
+          "prep_seconds": 0.06573229195782915,
+          "submit_seconds": 1.7452996250067372,
+          "wait_seconds": 0.6535746250010561,
+          "result_fetch_seconds": 0.525289083016105,
+          "driver_total_wall_seconds": 2.9241820000170264,
+          "connections": 3,
+          "counts": {
+            "1": 10
+          },
+          "shots": 10
+        },
+        {
+          "total_seconds": 4.047199502005242,
+          "prep_seconds": 0.06667570900754072,
+          "submit_seconds": 1.4359246249950957,
+          "wait_seconds": 2.025372835021699,
+          "result_fetch_seconds": 0.5192263329809066,
+          "driver_total_wall_seconds": 3.9805564600101206,
+          "connections": 4,
+          "counts": {
+            "0": 4,
+            "1": 6
+          },
+          "shots": 10
+        }
+      ]
+    }
+  }
+}

--- a/examples/measurements/2026-08-04-execution-three-arm.json
+++ b/examples/measurements/2026-08-04-execution-three-arm.json
@@ -1,0 +1,92 @@
+{
+  "schema": "qfw-execution-measurement-v0",
+  "timestamp": "2026-08-05T22:15:25.558587+00:00",
+  "host": "c5",
+  "shots": 10,
+  "repeat": 1,
+  "context": {
+    "base_url": "https://qccsw.ccs.ornl.gov:8443",
+    "provider_device_id": "default"
+  },
+  "connection_counting": {
+    "requested": true,
+    "port": 8443,
+    "supported": true
+  },
+  "libraries": {
+    "qrmi": {
+      "library": "qrmi",
+      "device_id": "ornl-iqm-20q",
+      "warm_seconds": 4.45731337700272,
+      "runs": [
+        {
+          "total_seconds": 0.9957263329997659,
+          "prep_seconds": 0.05858654103940353,
+          "submit_seconds": 0.1407548749994021,
+          "wait_seconds": 0.49478520898264833,
+          "result_fetch_seconds": 0.3015997079783119,
+          "driver_total_wall_seconds": 0.9371559589926619,
+          "connections": 1,
+          "provider_durations": null,
+          "counts": {
+            "0": 2,
+            "1": 8
+          },
+          "shots": 10
+        }
+      ]
+    },
+    "qdmi": {
+      "library": "qdmi",
+      "device_id": "ornl-iqm-20q",
+      "warm_seconds": 2.532944334001513,
+      "runs": [
+        {
+          "total_seconds": 3.8927366679999977,
+          "prep_seconds": 0.06659374901209958,
+          "submit_seconds": 1.41047487501055,
+          "wait_seconds": 1.9189470429846551,
+          "result_fetch_seconds": 0.496721000992693,
+          "driver_total_wall_seconds": 3.826161877019331,
+          "connections": 4,
+          "provider_durations": null,
+          "counts": {
+            "1": 10
+          },
+          "shots": 10
+        }
+      ]
+    },
+    "native": {
+      "library": "native",
+      "device_id": "ornl-iqm-20q",
+      "warm_seconds": 2.049220710003283,
+      "runs": [
+        {
+          "total_seconds": 3.9926918770070188,
+          "prep_seconds": 1.046512332977727,
+          "submit_seconds": 0.5061881260189693,
+          "wait_seconds": 1.932023293018574,
+          "result_fetch_seconds": 0.5079681249917485,
+          "driver_total_wall_seconds": 3.9282694179855753,
+          "connections": 6,
+          "provider_durations": {
+            "server_total_created_to_completed": 0.542143,
+            "created_to_station_received": 0.022003,
+            "queue_wait_received_to_validation_started": 0.03494,
+            "validation": 0.001171,
+            "compilation": 0.066206,
+            "execution": 0.107279,
+            "post_processing": 0.01051,
+            "ready_to_completed": 0.067385,
+            "pre_execution_created_to_execution_started": 0.340229
+          },
+          "counts": {
+            "1": 10
+          },
+          "shots": 10
+        }
+      ]
+    }
+  }
+}

--- a/examples/measurements/2026-08-04-introspection-three-arm.json
+++ b/examples/measurements/2026-08-04-introspection-three-arm.json
@@ -1,0 +1,494 @@
+[
+  {
+    "schema": "qfw-introspection-measurement-v0",
+    "timestamp": "2026-08-05T22:14:22.555804+00:00",
+    "host": "c5",
+    "warm_iterations": 5,
+    "context": {
+      "base_url": "https://qccsw.ccs.ornl.gov:8443",
+      "provider_device_id": "default"
+    },
+    "connection_counting": {
+      "requested": true,
+      "port": 8443,
+      "supported": true
+    },
+    "libraries": {
+      "qrmi": {
+        "library": "qrmi",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 3.91600769944489e-06,
+        "open_seconds": 0.005464708985527977,
+        "first_call_seconds": 1.4299504590162542,
+        "qubits_seen": 20,
+        "cold_seconds": 1.4354151680017821,
+        "cold_connections": 1,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.012426291999872774,
+              0.011797542014392093,
+              0.01157316699391231,
+              0.01175425000838004,
+              0.011578125006053597
+            ],
+            "median_seconds": 0.01175425000838004,
+            "min_seconds": 0.01157316699391231,
+            "max_seconds": 0.012426291999872774
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.017728625010931864,
+              0.01737679200596176,
+              0.01747983298264444,
+              0.017171709012473002,
+              0.017696334020001814
+            ],
+            "median_seconds": 0.01747983298264444,
+            "min_seconds": 0.017171709012473002,
+            "max_seconds": 0.017728625010931864
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              0.01954924999154173,
+              0.0185523749969434,
+              0.02040466698235832,
+              0.019158167007844895,
+              0.019083416991634294
+            ],
+            "median_seconds": 0.019158167007844895,
+            "min_seconds": 0.0185523749969434,
+            "max_seconds": 0.02040466698235832
+          }
+        },
+        "warm_connections": 0
+      },
+      "qdmi": {
+        "library": "qdmi",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 6.624992238357663e-06,
+        "open_seconds": 2.9179517519951332,
+        "first_call_seconds": 0.025808375008637086,
+        "qubits_seen": 20,
+        "cold_seconds": 2.9437601270037703,
+        "cold_connections": 5,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.016574084002058953,
+              0.013877790974220261,
+              0.012312750011915341,
+              0.011524250003276393,
+              0.011476792016765103
+            ],
+            "median_seconds": 0.012312750011915341,
+            "min_seconds": 0.011476792016765103,
+            "max_seconds": 0.016574084002058953
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.016679167019901797,
+              0.016931917023612186,
+              0.016158792015630752,
+              0.01629754199529998,
+              0.01647858298383653
+            ],
+            "median_seconds": 0.01647858298383653,
+            "min_seconds": 0.016158792015630752,
+            "max_seconds": 0.016931917023612186
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              0.012252084008650854,
+              0.012363542016828433,
+              0.012712167022982612,
+              0.012326125026447698,
+              0.012022459006402642
+            ],
+            "median_seconds": 0.012326125026447698,
+            "min_seconds": 0.012022459006402642,
+            "max_seconds": 0.012712167022982612
+          }
+        },
+        "warm_connections": 0
+      },
+      "native": {
+        "library": "native",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 0.0008223339973483235,
+        "open_seconds": 1.2759019170189276,
+        "first_call_seconds": 1.5551560420135502,
+        "qubits_seen": 20,
+        "cold_seconds": 2.831057959032478,
+        "cold_connections": 4,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.4669009589997586,
+              0.5159274170000572,
+              0.6080895010090899,
+              0.5345202079915907,
+              0.604920707992278
+            ],
+            "median_seconds": 0.5345202079915907,
+            "min_seconds": 0.4669009589997586,
+            "max_seconds": 0.6080895010090899
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.5201565419847611,
+              0.503245125990361,
+              0.6027516670001205,
+              0.5992967510246672,
+              0.5978261250129435
+            ],
+            "median_seconds": 0.5978261250129435,
+            "min_seconds": 0.503245125990361,
+            "max_seconds": 0.6027516670001205
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              1.8259317929914687,
+              1.5269513340026606,
+              1.7583159180067014,
+              1.5850991669867653,
+              1.6022010000015143
+            ],
+            "median_seconds": 1.6022010000015143,
+            "min_seconds": 1.5269513340026606,
+            "max_seconds": 1.8259317929914687
+          }
+        },
+        "warm_connections": 25
+      }
+    }
+  },
+  {
+    "schema": "qfw-introspection-measurement-v0",
+    "timestamp": "2026-08-05T22:14:44.489154+00:00",
+    "host": "c5",
+    "warm_iterations": 5,
+    "context": {
+      "base_url": "https://qccsw.ccs.ornl.gov:8443",
+      "provider_device_id": "default"
+    },
+    "connection_counting": {
+      "requested": true,
+      "port": 8443,
+      "supported": true
+    },
+    "libraries": {
+      "qrmi": {
+        "library": "qrmi",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 3.1249946914613247e-06,
+        "open_seconds": 0.002935583994258195,
+        "first_call_seconds": 0.8901081250223797,
+        "qubits_seen": 20,
+        "cold_seconds": 0.8930437090166379,
+        "cold_connections": 1,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.013958250026917085,
+              0.012224249978316948,
+              0.011737875000108033,
+              0.01137466699583456,
+              0.011669542000163347
+            ],
+            "median_seconds": 0.011737875000108033,
+            "min_seconds": 0.01137466699583456,
+            "max_seconds": 0.013958250026917085
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.017280208005104214,
+              0.016860583011293784,
+              0.01672620899626054,
+              0.01669350001611747,
+              0.016706624999642372
+            ],
+            "median_seconds": 0.01672620899626054,
+            "min_seconds": 0.01669350001611747,
+            "max_seconds": 0.017280208005104214
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              0.019107165979221463,
+              0.018406957999104634,
+              0.018166415975429118,
+              0.018114124977728352,
+              0.018167125002946705
+            ],
+            "median_seconds": 0.018167125002946705,
+            "min_seconds": 0.018114124977728352,
+            "max_seconds": 0.019107165979221463
+          }
+        },
+        "warm_connections": 0
+      },
+      "qdmi": {
+        "library": "qdmi",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 7.041991921141744e-06,
+        "open_seconds": 2.8632232089876197,
+        "first_call_seconds": 0.01780000000144355,
+        "qubits_seen": 20,
+        "cold_seconds": 2.8810232089890633,
+        "cold_connections": 5,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.018091832986101508,
+              0.014413500000955537,
+              0.013096667011268437,
+              0.012133416981669143,
+              0.01167429200722836
+            ],
+            "median_seconds": 0.013096667011268437,
+            "min_seconds": 0.01167429200722836,
+            "max_seconds": 0.018091832986101508
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.017274832993280143,
+              0.01696066599106416,
+              0.01596233301097527,
+              0.015955916984239593,
+              0.015982957993401214
+            ],
+            "median_seconds": 0.015982957993401214,
+            "min_seconds": 0.015955916984239593,
+            "max_seconds": 0.017274832993280143
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              0.012086833012290299,
+              0.012060541979735717,
+              0.012210957997012883,
+              0.012051166995661333,
+              0.012078667001333088
+            ],
+            "median_seconds": 0.012078667001333088,
+            "min_seconds": 0.012051166995661333,
+            "max_seconds": 0.012210957997012883
+          }
+        },
+        "warm_connections": 0
+      },
+      "native": {
+        "library": "native",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 0.0008513339853379875,
+        "open_seconds": 1.2219560839876067,
+        "first_call_seconds": 1.526734168000985,
+        "qubits_seen": 20,
+        "cold_seconds": 2.7486902519885916,
+        "cold_connections": 4,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.5749752499978058,
+              0.49808379099704325,
+              0.5096164999995381,
+              0.5998878340178635,
+              0.5964439589879476
+            ],
+            "median_seconds": 0.5749752499978058,
+            "min_seconds": 0.49808379099704325,
+            "max_seconds": 0.5998878340178635
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.5166205840068869,
+              0.49750008300179616,
+              0.5032894589821808,
+              0.6063552499981597,
+              0.503237958997488
+            ],
+            "median_seconds": 0.5032894589821808,
+            "min_seconds": 0.49750008300179616,
+            "max_seconds": 0.6063552499981597
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              1.7527174169954378,
+              1.6905251260031946,
+              1.6580393339972943,
+              1.4689055839844514,
+              1.5098778340034187
+            ],
+            "median_seconds": 1.6580393339972943,
+            "min_seconds": 1.4689055839844514,
+            "max_seconds": 1.7527174169954378
+          }
+        },
+        "warm_connections": 25
+      }
+    }
+  },
+  {
+    "schema": "qfw-introspection-measurement-v0",
+    "timestamp": "2026-08-05T22:15:05.366253+00:00",
+    "host": "c5",
+    "warm_iterations": 5,
+    "context": {
+      "base_url": "https://qccsw.ccs.ornl.gov:8443",
+      "provider_device_id": "default"
+    },
+    "connection_counting": {
+      "requested": true,
+      "port": 8443,
+      "supported": true
+    },
+    "libraries": {
+      "qrmi": {
+        "library": "qrmi",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 3.2919924706220627e-06,
+        "open_seconds": 0.003221332997782156,
+        "first_call_seconds": 0.9149270009947941,
+        "qubits_seen": 20,
+        "cold_seconds": 0.9181483339925762,
+        "cold_connections": 1,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.012995833007153124,
+              0.011762750014895573,
+              0.011797207989729941,
+              0.011514499987242743,
+              0.011512208002386615
+            ],
+            "median_seconds": 0.011762750014895573,
+            "min_seconds": 0.011512208002386615,
+            "max_seconds": 0.012995833007153124
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.017027041991241276,
+              0.01671704201726243,
+              0.016460916987853125,
+              0.016450416995212436,
+              0.016574582987232134
+            ],
+            "median_seconds": 0.016574582987232134,
+            "min_seconds": 0.016450416995212436,
+            "max_seconds": 0.017027041991241276
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              0.018932791019324213,
+              0.018288457999005914,
+              0.018184791988460347,
+              0.018046374985715374,
+              0.018081708025420085
+            ],
+            "median_seconds": 0.018184791988460347,
+            "min_seconds": 0.018046374985715374,
+            "max_seconds": 0.018932791019324213
+          }
+        },
+        "warm_connections": 0
+      },
+      "qdmi": {
+        "library": "qdmi",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 6.459013093262911e-06,
+        "open_seconds": 2.602106126025319,
+        "first_call_seconds": 0.01947237498825416,
+        "qubits_seen": 20,
+        "cold_seconds": 2.6215785010135733,
+        "cold_connections": 5,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.013020125014008954,
+              0.013218457985203713,
+              0.013179082976421341,
+              0.01338737501646392,
+              0.01307279200409539
+            ],
+            "median_seconds": 0.013179082976421341,
+            "min_seconds": 0.013020125014008954,
+            "max_seconds": 0.01338737501646392
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.017728125007124618,
+              0.017318166996119544,
+              0.01697891700314358,
+              0.017191666993312538,
+              0.017225916002644226
+            ],
+            "median_seconds": 0.017225916002644226,
+            "min_seconds": 0.01697891700314358,
+            "max_seconds": 0.017728125007124618
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              0.012808250001398847,
+              0.013060375000350177,
+              0.013321791018825024,
+              0.013175540982047096,
+              0.012355584010947496
+            ],
+            "median_seconds": 0.013060375000350177,
+            "min_seconds": 0.012355584010947496,
+            "max_seconds": 0.013321791018825024
+          }
+        },
+        "warm_connections": 0
+      },
+      "native": {
+        "library": "native",
+        "device_id": "ornl-iqm-20q",
+        "construct_seconds": 0.0007899999909568578,
+        "open_seconds": 1.3144460420007817,
+        "first_call_seconds": 1.5470900850195903,
+        "qubits_seen": 20,
+        "cold_seconds": 2.861536127020372,
+        "cold_connections": 4,
+        "warm": {
+          "get_device_info": {
+            "samples": [
+              0.47516904200892895,
+              0.49935208397801034,
+              0.48875800002133474,
+              0.5125729999854229,
+              0.498407250008313
+            ],
+            "median_seconds": 0.498407250008313,
+            "min_seconds": 0.47516904200892895,
+            "max_seconds": 0.5125729999854229
+          },
+          "get_coupling_graph": {
+            "samples": [
+              0.5010105420078617,
+              0.5003575419832487,
+              0.505330915999366,
+              0.4936750420019962,
+              0.5049817920080386
+            ],
+            "median_seconds": 0.5010105420078617,
+            "min_seconds": 0.4936750420019962,
+            "max_seconds": 0.505330915999366
+          },
+          "get_calibration_snapshot": {
+            "samples": [
+              1.638594458985608,
+              1.5065817499998957,
+              1.5438162499922328,
+              1.4854696679976769,
+              1.5377942089980934
+            ],
+            "median_seconds": 1.5377942089980934,
+            "min_seconds": 1.4854696679976769,
+            "max_seconds": 1.638594458985608
+          }
+        },
+        "warm_connections": 25
+      }
+    }
+  }
+]

--- a/examples/measurements/README.md
+++ b/examples/measurements/README.md
@@ -130,6 +130,47 @@ as positional by reversing the library order and watching the penalty follow
 position. The script now warms the transcoder before timing; prep is
 order-independent.
 
+## Three-arm records: `2026-08-04-introspection-three-arm.json`, `2026-08-04-execution-three-arm.json`
+
+The same two measurements re-run with QFw's **native IQM service client**
+(`svc_iqm_qpm`) added as a third path, talking to `iqm-client` directly. This is
+the baseline the interface-convergence question needs: it separates what the
+shim layers cost from what they save.
+
+Introspection, median of 3 cold samples:
+
+| | cold | cold conns | warm `get_device_info` | new conns during warm |
+|---|---|---|---|---|
+| QRMI | 918.1 ms | 1 | 11.8 ms | 0 |
+| QDMI | 2881.0 ms | 5 | 13.1 ms | 0 |
+| native | 2831.1 ms | 4 | **512.6 ms** | **25** |
+
+Execution, one circuit each:
+
+| | total | conns | provider timing |
+|---|---|---|---|
+| QRMI | 995.7 ms | 1 | none |
+| QDMI | 3892.7 ms | 4 | none |
+| native | 3992.7 ms | 6 | queue 34.9 ms, execution 107.3 ms |
+
+**The interface layers are not pure overhead — they add a cache the native
+client does not have.** Both QRMI and QDMI serve repeat introspection locally,
+opening no connection. The native path holds no introspection cache at all:
+every call re-fetches, 25 connections across a warm phase, and each call costs
+about 40x what the cached paths cost. It also re-fetches the dynamic
+architecture inside `run_circuit`, which is why its execution `prep` is high.
+
+**Only the native path reports provider-side timing.** It reads the IQM job
+timeline and can separate queue wait from execution — 34.9 ms and 107.3 ms in
+the run above. Neither QRMI nor QDMI passes that through. The information is
+not missing at the provider; both interfaces discard it. That materially
+changes the reading of the Telemetry gap in the analysis document: it is a
+choice made by the abstraction layers, not a limitation of the device.
+
+Worth noting how small the device's own numbers are. Execution took 107 ms on
+hardware while the client-side total was 1-4 seconds. Under these conditions
+almost everything measured is client and network cost, not QPU time.
+
 **Reproducing**
 
 ```bash

--- a/examples/measurements/README.md
+++ b/examples/measurements/README.md
@@ -86,6 +86,50 @@ interface, and it is fixable there by retaining a session across requests.
   higher cold cost buys strictly more device data.
 - One device, one session, five samples.
 
+## `2026-08-04-execution-phases.json`
+
+Produced by `examples/measure_shim_execution.py --repeat 2
+--count-connections`. Same device, same path, same versions as above. **Uses
+QPU time**: two circuits per library, one qubit, 10 shots.
+
+Medians per run:
+
+| | QRMI | QDMI |
+|---|---|---|
+| prep (transcode + payload assembly) | 67.7 ms | 66.2 ms |
+| submit | 133.1 ms | 1590.6 ms |
+| wait (poll to terminal) | 589.9 ms | 1339.5 ms |
+| fetch | 300.1 ms | 522.3 ms |
+| **total** | **1090.8 ms** | **3518.5 ms** |
+| connections opened | 1 | 3 |
+
+Both returned `{'1': 10}` — an X gate on |0⟩, no readout error at 10 shots.
+
+**Payload assembly costs nothing.** This measurement was built to test whether
+the envelope-assembly difference between the libraries is expensive: QRMI's
+caller builds the whole IQM run request, QDMI's caller submits a single circuit
+and the device implementation assembles the request. The two are within 1.5 ms
+of each other. The difference is architecturally significant — it decides who
+owns shots, calibration selection, and provenance — but it is not a performance
+difference.
+
+**The gap is connection handling again, now multiplied by polling.** The same
+per-request reconnect seen in introspection applies here, and execution makes
+several requests: submit, one or more polls, then fetch. QRMI does all of them
+over one pooled connection; QDMI opens a new one each time.
+
+**Read `wait` with care.** It includes device queue time, which neither
+interface reports separately (see the Telemetry axis of the QRMI/QDMI analysis),
+so it varies with what else is on the instrument. `submit` and `fetch` are the
+interpretable phases; `wait` is confounded.
+
+**Ordering artifact, since fixed.** The first version charged the first library
+measured about 3.4 seconds of lazy Qiskit imports inside `build_iqm_circuit`,
+making its payload assembly look ~57x more expensive than the second. Confirmed
+as positional by reversing the library order and watching the penalty follow
+position. The script now warms the transcoder before timing; prep is
+order-independent.
+
 **Reproducing**
 
 ```bash
@@ -99,4 +143,10 @@ opens no connection on either path:
 
 ```bash
 python examples/measure_shim_introspection.py --repeat 5 --warm-iterations 10 --count-connections
+```
+
+Execution (**uses QPU time** — keep `--repeat` and `--shots` small):
+
+```bash
+python examples/measure_shim_execution.py --repeat 2 --count-connections
 ```

--- a/examples/measurements/README.md
+++ b/examples/measurements/README.md
@@ -21,6 +21,12 @@ Produced by `examples/measure_shim_introspection.py --repeat 5
 | Warm iterations | 10 per call, per sample |
 | Payload validated | 20 qubits returned on every sample |
 
+**Versions.** These figures are implementation-specific and will change as the
+libraries move, so they mean nothing without the versions they were taken
+against: `qrmi` 0.17.2, `iqm-qdmi` 1.2.0, `mqt-core` 3.7.0 (QDMI headers and
+FoMaC), `iqm-client` 34.0.1, `iqm-station-control-client` 12.1.1, `iqm-pulse`
+13.0.1, `qhw-iqm` 0.1.0.
+
 **Medians**
 
 | | QRMI | QDMI |
@@ -55,10 +61,11 @@ opened toward the endpoint during one cold introspection:
 | QDMI | ~5 | **5** | 5 |
 
 QRMI's Rust client (`reqwest`) pools and reuses one connection. QDMI-on-IQM
-calls `curl_easy_init()` per request and `curl_easy_cleanup()` after it
-(`src/internal/curl_http_client.cpp`); libcurl's connection cache lives on the
-easy handle, so each request opens a fresh connection and repeats the TLS
-handshake.
+1.2.0 issues each request through cpr's free-function API (`cpr::Get` /
+`cpr::Post` in `src/internal/http_client.cpp`), which constructs and destroys a
+session — and with it the underlying libcurl handle and its connection cache —
+per call. No session is retained across requests, so each one reconnects and
+repeats the TLS handshake.
 
 Solving the two medians for a uniform per-request cost and a uniform handshake
 cost gives roughly 330 ms per request and 350 ms per handshake under these
@@ -67,8 +74,7 @@ would expect over a tunnel. That is a derived model from two data points, not a
 measurement; it is offered only as a consistency check on the explanation.
 
 This is an implementation property of QDMI-on-IQM, not a property of the QDMI
-interface, and it is fixable there (a shared handle, or reusing the easy
-handle across requests).
+interface, and it is fixable there by retaining a session across requests.
 
 **Caveats**
 


### PR DESCRIPTION
Follow-on to #34, which covered introspection cost. This adds the execution measurement, a native-client baseline, and two corrections to what #34 landed.

## Execution: does the envelope-assembly difference cost anything?

`examples/measure_shim_execution.py` submits the same one-qubit circuit through each path and decomposes where the time goes. **Uses QPU time** — defaults to one circuit per path at 10 shots.

The motivating question was whether the split recorded in the Runtime Submission axis is expensive: QRMI's caller builds the whole IQM run request, QDMI's caller submits a single circuit and the device library assembles the request around it.

It is not. Payload assembly measured 67.7 ms for QRMI against 66.2 ms for QDMI — within noise. A clean negative result, and worth having: that difference is architecturally significant, since it decides who owns shots, calibration selection and provenance, but it is not a performance difference.

What differs is everything after, and it is the same cause as #34: connection handling, now multiplied by polling, because execution makes several requests where introspection made one batch.

## Native IQM client as a third arm

Both measurements now also run QFw's own `svc_iqm_qpm` client, talking to `iqm-client` directly. That is the baseline the interface-convergence question needs: without it the comparison can say which shim library is cheaper, but not what either costs relative to having no interface layer at all.

`IQMServiceClient` already exposes the same call surface, so `NativeAdapter` maps its two differing return shapes rather than modifying the native service, which stays untouched by the shim work.

Two results the two-way comparison could not produce.

**The interface layers are not pure overhead — they add a cache the provider client lacks.** Repeat `get_device_info` costs 11.8 ms through QRMI and 13.1 ms through QDMI against **512.6 ms** natively, with 25 fresh connections across a warm phase where both interfaces opened none. On the most common access pattern — ask the same device something more than once — both interfaces are roughly forty times cheaper than talking to the provider directly. Cold start shows no penalty either: native sits at 2831 ms, between QRMI's 1335 ms and QDMI-on-IQM's 3377 ms.

**Only the native path reports provider-side timing.** It reads the IQM job timeline and separates queue wait from execution — 34.9 ms and 107.3 ms on a circuit whose client-side elapsed time was several seconds. Neither QRMI nor QDMI passes any of it through. The analysis document previously recorded queue-versus-execution as unavailable from both interfaces, implying the provider does not supply it; it does, and both discard it. That is a stronger finding, and the spec requirement becomes passthrough rather than a new timing model.

Worth noting how small the device's own numbers are: 107 ms of execution against client-side totals of 1–4 seconds. Under these conditions almost everything being measured is client and network cost, not QPU time.

## Two corrections to what #34 landed

**A source citation pointed at code that never ran.** The connection-reuse explanation cited `curl_easy_init()`/`curl_easy_cleanup()` in `src/internal/curl_http_client.cpp` — a file that does not exist in `iqm-qdmi` 1.2.0. It was read from a local working tree sitting on an abandoned feature branch at v1.1.1+2. The measured result is unaffected (five connections for five requests, observed at runtime), but the mechanism is restated for 1.2.0, which issues each request through cpr's free-function API and so retains no session across requests. Versions are now recorded alongside the numbers so this class of error is visible.

**The connection sampler could outlive its parent.** It polls until the parent writes a stop file; if the parent is killed or crashes, nothing ends the loop, and it does not fail either, because the `/proc` read fails softly. Development runs left 21 orphaned samplers on a compute node consuming 145% CPU. It now exits when its parent is gone, with a lifetime backstop.

## Also

The connection sampler, payload validation and endpoint helpers move to `examples/measurement_support.py`, shared by both scripts. That code manages a subprocess and has already produced one CPU incident; it should exist once.

An ordering artifact was removed before the execution numbers were trusted: `build_iqm_circuit()` imports Qiskit lazily, so the first path measured was charged ~3.4 s of module import and appeared to have ~57x the assembly cost of the second. Confirmed positional by reversing the order and watching the penalty follow position; the transcoder is now warmed before timing.

## Caveats, unchanged from #34

Measured over an SSH tunnel from outside ORNL, which amplifies per-connection cost — the on-site ratio should be smaller, and an on-site re-run remains the most valuable follow-up. The payloads are not equivalent: QDMI's session init also fetches the static architecture that QRMI does not expose. `wait` includes device queue time, which neither interface reports separately, so `submit` and `fetch` are the interpretable phases.
