### PR TITLE
QFw: repair the flake8 baseline so ci-syntax can pass

### DIFF
--- a/.github/scripts/.flake8
+++ b/.github/scripts/.flake8
@@ -1,3 +1,28 @@
 [flake8]
-ignore = W191,E101,E265,E203
+# QFw is a tab-indented codebase. pycodestyle's indentation checks assume
+# spaces, so several of them misfire here and are disabled below.
+#
+# Use extend-ignore, NOT ignore. "ignore" REPLACES pycodestyle's default
+# ignore list (E121,E123,E126,E226,E24,E704,W503,W504); "extend-ignore" adds
+# to it. Switching this key back to "ignore" silently re-enables ~65
+# violations across the tree, most of them E126 and W503.
+#
+#   W191  indentation contains tabs                 - by design
+#   E101  indentation contains mixed whitespace     - by design
+#   E265  block comment should start with '# '      - existing style
+#   E203  whitespace before ':'                     - conflicts with slicing style
+#   E117  over-indented                             - see note below
+#   E128  continuation line under-indented for visual indent
+#
+# E117: pycodestyle picks indent_char from the first physical line in the file
+# that starts with whitespace, counting lines inside string literals. A module
+# docstring with a space-indented body therefore marks the whole file as
+# space-indented, after which every one-tab block (8 columns) reads as
+# "over-indented". Both files under examples/ trip this.
+#
+# E128: visual-indent alignment lines a continuation up with the column after
+# an opening bracket. Tabs advance to 8-column stops, so that column is not
+# reachable. E121/E123/E126 are off by default for the same reason; E128
+# simply is not.
+extend-ignore = W191,E101,E265,E203,E117,E128
 max-line-length = 120

--- a/examples/measure_shim_execution.py
+++ b/examples/measure_shim_execution.py
@@ -56,7 +56,7 @@ from datetime import datetime, timezone
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from measurement_support import (  # noqa: E402
-	ConnectionSampler, MeasurementError, driver_for, endpoint_context,
+	ConnectionSampler, driver_for, endpoint_context,
 	endpoint_port, fmt_ms, open_handle, require_counts, require_qubits)
 
 # One qubit, flipped and measured: the smallest circuit that still exercises

--- a/examples/measure_shim_introspection.py
+++ b/examples/measure_shim_introspection.py
@@ -179,7 +179,6 @@ def run_repeated(args):
 	return records
 
 
-
 def render(records):
 	first = records[0]
 	context = first.get("context", {})

--- a/services/svc_iqm_qpm/util_iqm.py
+++ b/services/svc_iqm_qpm/util_iqm.py
@@ -3,7 +3,7 @@ from defw_exception import DEFwExecutionError
 from util.device_access import (
 	QPU_DEVICE_ENV, resolve_device_access, resolve_qpu_user)
 from util.iqm_transcode import (
-	active_qubits, build_iqm_circuit, to_jsonable)
+	build_iqm_circuit, to_jsonable)
 from urllib.parse import urlsplit, urlunsplit
 from uuid import UUID
 import inspect

--- a/services/svc_lib_qpm/drivers/qrmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qrmi_driver.py
@@ -44,11 +44,11 @@ def _status_str(status):
 class QrmiDriver(BaseDriver):
 	name = "qrmi"
 	CAPABILITIES = frozenset({
-		"get_device_info",          # target() -> qhw-iqm device
-		"get_coupling_graph",       # target() -> qhw-iqm coupling
-		"get_calibration_snapshot", # target() -> qhw-iqm calibration
-		"get_dynamic_backend_info", # target() -> dynamic architecture
-		"get_backend_info",         # target() -> native composite + qhw device
+		"get_device_info",           # target() -> qhw-iqm device
+		"get_coupling_graph",        # target() -> qhw-iqm coupling
+		"get_calibration_snapshot",  # target() -> qhw-iqm calibration
+		"get_dynamic_backend_info",  # target() -> dynamic architecture
+		"get_backend_info",          # target() -> native composite + qhw device
 		"run_circuit",
 		"get_last_job_timing",
 		"get_last_job_metadata",

--- a/services/util/iqm_transcode.py
+++ b/services/util/iqm_transcode.py
@@ -32,6 +32,7 @@ def to_jsonable(value):
 		return to_jsonable(value.dict())
 	return str(value)
 
+
 def load_iqm_pulse_module():
 	try:
 		from iqm.pulse import Circuit, CircuitOperation
@@ -40,6 +41,7 @@ def load_iqm_pulse_module():
 			f"failed to import iqm.pulse circuit objects: {exc}") from exc
 	return Circuit, CircuitOperation
 
+
 def active_qubits(dynamic_architecture):
 	data = to_jsonable(dynamic_architecture)
 	qubits = data.get("qubits") or []
@@ -47,6 +49,7 @@ def active_qubits(dynamic_architecture):
 		raise DEFwExecutionError(
 			"IQM dynamic architecture did not report active qubits")
 	return [str(qubit) for qubit in qubits]
+
 
 def logical_to_physical_qubits(qasm_circuit, dynamic_architecture, mapping):
 	physical = active_qubits(dynamic_architecture)
@@ -65,6 +68,7 @@ def logical_to_physical_qubits(qasm_circuit, dynamic_architecture, mapping):
 			f"{len(physical)} active qubits")
 	return {index: physical[index] for index in range(num_qubits)}
 
+
 def eval_angle(value):
 	allowed = {"pi": math.pi}
 	try:
@@ -72,6 +76,7 @@ def eval_angle(value):
 	except Exception as exc:
 		raise DEFwExecutionError(
 			f"unsupported angle expression in OpenQASM: {value!r}") from exc
+
 
 def split_qasm_statements(qasm):
 	statements = []
@@ -85,6 +90,7 @@ def split_qasm_statements(qasm):
 				statements.append(part)
 	return statements
 
+
 def load_qiskit_circuit(qasm):
 	try:
 		from qiskit import QuantumCircuit
@@ -96,6 +102,7 @@ def load_qiskit_circuit(qasm):
 	except Exception as exc:
 		raise DEFwExecutionError(
 			f"failed to parse OpenQASM through qiskit: {exc}") from exc
+
 
 def serialize_qiskit_to_iqm(qasm, dynamic_architecture, mapping):
 	Circuit, _ = load_iqm_pulse_module()
@@ -123,6 +130,7 @@ def serialize_qiskit_to_iqm(qasm, dynamic_architecture, mapping):
 		metadata={"logical_to_physical": index_to_name},
 	)
 
+
 def parse_ref(ref, qregs):
 	ref = ref.strip()
 	match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\[(\d+)\]$", ref)
@@ -134,6 +142,7 @@ def parse_ref(ref, qregs):
 	if ref in qregs:
 		return [(ref, index) for index in range(qregs[ref])]
 	raise DEFwExecutionError(f"unknown OpenQASM qubit reference {ref}")
+
 
 def build_manual_iqm_circuit(qasm, dynamic_architecture, mapping):
 	Circuit, CircuitOperation = load_iqm_pulse_module()
@@ -245,6 +254,7 @@ def build_manual_iqm_circuit(qasm, dynamic_architecture, mapping):
 		instructions=tuple(operations),
 		metadata={"logical_to_physical": to_jsonable(qubit_map)},
 	)
+
 
 def build_iqm_circuit(qasm, dynamic_architecture, mapping):
 	try:


### PR DESCRIPTION
`ci-syntax` has failed on `main` since 2026-05-04 — roughly thirty consecutive runs — so every PR since has inherited a red check that says nothing about the PR. #30, for example, touches only `docs/benchmarking-design.md` and still shows a lint failure.

The 202 reported violations broke down into two config faults and a small tail of real ones.

### `ignore` vs `extend-ignore` — 65 violations

The flake8 `ignore` key **replaces** the default ignore list (`E121,E123,E126,E226,E24,E704,W503,W504`); `extend-ignore` adds to it. The config used `ignore`, which switched all eight defaults back on: 35 E126, 28 W503, 2 W504.

### E117 — 74 violations

pycodestyle takes `indent_char` from the first physical line in a file that starts with whitespace, and it does not skip lines inside string literals. Both files under `examples/` open with a module docstring whose body is space-indented for legibility, so pycodestyle reads the file as space-indented, expects 4, and flags every one-tab block — 8 columns — as over-indented.

Verified by retabbing one docstring in a scratch copy: 47 E117 to 0. Doing that for real would wreck the aligned prose, so E117 is disabled instead.

### E128 — 48 violations, 15 files

Visual-indent alignment targets the column after an opening bracket; tabs only reach 8-column stops, so it is not reachable. `E121`/`E123`/`E126` are off by default on that same logic — `E128` merely is not. This codebase is tab-indented and already disables `W191` and `E101`.

### The remaining 15

Genuine, and fixed here rather than suppressed: two unused imports, ten missing blank lines before top-level defs in `iqm_transcode.py`, two inline comments a space short, one extra blank line.

### Verification

Both CI scripts pass locally against flake8 7.3.0, the version CI resolves:

- `.github/scripts/ci-syntax.sh` — exit 0
- `.github/scripts/ci-mock.sh` — 24 passed

Note that the `py_compile` half of `ci-syntax` had never actually run: `set -e` stopped the script at the flake8 failure every time. It is clean.

The new `.flake8` carries comments explaining why each check is disabled, and a warning against switching the key back to `ignore`.
