### PR TITLE
QFw: restore QDMI on the task timing and metadata calls

### DIFF
--- a/services/svc_lib_qpm/descriptor.py
+++ b/services/svc_lib_qpm/descriptor.py
@@ -12,8 +12,8 @@ DEFAULT_CAPS = {
 	# Execution is composable for the QRMI-vs-QDMI comparison: no lib routes to
 	# the execution owner (qrmi); --lib qdmi runs the same circuit through QDMI.
 	"run_circuit": ["qrmi", "qdmi"],
-	"get_task_timing": ["qrmi"],
-	"get_task_metadata": ["qrmi"],
+	"get_task_timing": ["qrmi", "qdmi"],
+	"get_task_metadata": ["qrmi", "qdmi"],
 }
 
 DEFAULT_LIBRARIES = ["qrmi", "qdmi"]

--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -42,8 +42,8 @@ class QdmiDriver(BaseDriver):
 		"get_coupling_graph",
 		"get_calibration_snapshot",
 		"run_circuit",
-		"get_last_job_timing",
-		"get_last_job_metadata",
+		"get_task_timing",
+		"get_task_metadata",
 	})
 
 	def __init__(self, descriptor=None):
@@ -298,7 +298,7 @@ class QdmiDriver(BaseDriver):
 					f"QDMI job timed out after {timeout}s (status {state!r})")
 			time.sleep(max(poll, 0.0))
 
-	# --- last-job timing / metadata (from the cached run_circuit job) ----
+	# --- task timing / metadata (from the cached run_circuit job) -------
 
 	def _last_job_for(self, cid):
 		job = self._last_job
@@ -310,7 +310,7 @@ class QdmiDriver(BaseDriver):
 				f"{job.get('cid')!r})")
 		return job
 
-	def get_last_job_timing(self, cid=None):
+	def get_task_timing(self, cid=None):
 		job = self._last_job_for(cid)
 		return {
 			"cid": job.get("cid"),
@@ -318,7 +318,7 @@ class QdmiDriver(BaseDriver):
 			"status": job.get("status"),
 			"timing": job.get("timing") or {}}
 
-	def get_last_job_metadata(self, cid=None):
+	def get_task_metadata(self, cid=None):
 		job = self._last_job_for(cid)
 		return {
 			"cid": job.get("cid"),


### PR DESCRIPTION
## What

The QPM contract renamed `get_last_job_timing`/`get_last_job_metadata` to `get_task_timing`/`get_task_metadata`. `frontend.py`, `svc_qrc.py` and `qrmi_driver.py` all moved together. `qdmi_driver.py` did not.

Routing filters candidates on the driver's `CAPABILITIES` set, so QDMI stopped advertising both calls and its two methods became unreachable. `descriptor.py` had its defaults narrowed from `["qrmi", "qdmi"]` to `["qrmi"]`, which made the symptom go away without fixing the cause.

This renames the QDMI driver's capabilities and methods to match the contract and restores both calls to `["qrmi", "qdmi"]`.

## Why it matters

Comparing the two libraries call by call is the point of the shim. The execution facet had quietly lost its QDMI arm, so any QRMI-vs-QDMI comparison on timing or metadata was silently reduced to a single library.

## Testing

Verified against the ORNL 20-qubit device. The per-resource capability map now reports both libraries on both calls:

```
get_task_timing            ['qrmi', 'qdmi']
get_task_metadata          ['qrmi', 'qdmi']
```

The shim smoke test passes, including live introspection through both libraries (20 qubits, 30 edges, cross-library agreement).