### PR TITLE
QFw: expose the shim capability map on the telemetry API

### DIFF
--- a/service-apis/api_qpm_telemetry/api_qpm_telemetry.py
+++ b/service-apis/api_qpm_telemetry/api_qpm_telemetry.py
@@ -20,6 +20,9 @@ class QPMTelemetry(QPMRemoteBase):
 			       token=None):
 		pass
 
+	def capability_map(self, token=None):
+		pass
+
 	def get_telemetry_access_model(self, token=None):
 		pass
 

--- a/services/svc_lib_qpm/svc_qpm.py
+++ b/services/svc_lib_qpm/svc_qpm.py
@@ -38,7 +38,7 @@ class QPM(UTIL_QPM):
 		info['qfw_backend'] = 'iqm'
 		return info
 
-	def capability_map(self):
+	def capability_map(self, token=None):
 		return self.qrc.capability_map()
 
 	def get_backend_info(self, lib=None, token=None):


### PR DESCRIPTION
## What

The QPM API split moved every client-callable method onto a category class. `capability_map` was left behind: it still exists on the shim QPM, `svc_qrc` and the frontend, but it is declared on no `api_qpm_*` class.

`BaseRemote.__getattribute__` resolves methods with `object.__getattribute__`, so a method not declared on the category class is not reachable over RPC at all. `examples/tests/test_shim_smoke.py` dropped its `fetch_capability_map` helper and now hardcodes an empty map, which is consistent with the call no longer being available.

This declares `capability_map` on `QPMTelemetry` and accepts `token` on the service method to match the other telemetry calls.

## Why it matters

The capability map is the shim's per-resource gap map: the record of which library covers which call. A client that cannot read it cannot see the QRMI/QDMI coverage differences the shim exists to surface.

## Worth a look before merging

Only the shim QPM implements `capability_map` today. Declaring it on `QPMTelemetry` makes it callable against any QPM, and a non-shim QPM would fail server-side. That mirrors how the shim-specific `lib=` keyword already sits on the telemetry calls, but if you would rather it live on a shim-only surface, or want the other QPMs to grow a default, say so and I will rework it.

## Testing

Verified in the install tree that the method is declared on `QPMTelemetry` and that the shim's service signature accepts `token`.