### PR TITLE
QFw: repair the shim measurement scripts for the v0.1 runtime

### DIFF
--- a/examples/measure_shim_execution.py
+++ b/examples/measure_shim_execution.py
@@ -140,7 +140,7 @@ def measure_library(library, device_id, args, count_port=None):
 		# The drivers time submit/wait/fetch from their own clock, started just
 		# before submission. Anything before that -- transcode and payload
 		# assembly -- is the difference against the total measured here.
-		driver_timing = (driver.get_last_job_timing() or {}).get("timing") or {}
+		driver_timing = (driver.get_task_timing() or {}).get("timing") or {}
 		submit = driver_timing.get("submit_seconds")
 		wait = driver_timing.get("wait_seconds")
 		fetch = driver_timing.get("result_fetch_seconds")

--- a/examples/measurement_support.py
+++ b/examples/measurement_support.py
@@ -10,6 +10,10 @@ import sys
 import time
 from urllib.parse import urlsplit
 
+# DEFw's bootstrap is what puts its python/service-apis on sys.path. Anything
+# under svc_lib_qpm reaches api_events on import, so this has to come first.
+import defw  # noqa: E402,F401
+
 
 class MeasurementError(Exception):
 	"""A sample was taken but cannot be trusted."""
@@ -229,13 +233,13 @@ class NativeAdapter:
 
 	`svc_iqm_qpm.util_iqm.IQMServiceClient` already exposes get_device_info,
 	get_coupling_graph, get_calibration_snapshot, run_circuit and
-	get_last_job_timing. Two return shapes differ, so they are adapted here
+	get_task_timing. Two return shapes differ, so they are adapted here
 	rather than by touching the native service, which is deliberately
 	unmodified by the shim work:
 
 	  run_circuit          returns {"counts", "qhw_result"}; the drivers return
 	                       the qhw record directly.
-	  get_last_job_timing  returns an iqm-timing-summary-v1 record whose
+	  get_task_timing      returns an iqm-timing-summary-v1 record whose
 	                       client-side spans live under "client_wall_seconds".
 
 	That second difference is worth more than the adaptation. The native record
@@ -271,8 +275,8 @@ class NativeAdapter:
 			return out["qhw_result"]
 		return out
 
-	def get_last_job_timing(self, cid=None):
-		summary = self._client.get_last_job_timing(cid) or {}
+	def get_task_timing(self, cid=None):
+		summary = self._client.get_task_timing(cid) or {}
 		self._last_summary = summary
 		wall = summary.get("client_wall_seconds") or {}
 		return {"timing": {


### PR DESCRIPTION
## What

Both shim measurement scripts stopped running against the current runtime, for two unrelated reasons.

**The renamed call.** They still called `get_last_job_timing`, renamed to `get_task_timing`. This hit every arm — the two shim drivers and the native IQM service client alike — so all three paths reported themselves unavailable:

```
qrmi     unavailable: AttributeError: 'QrmiDriver' object has no attribute 'get_last_job_timing'
qdmi     unavailable: AttributeError: 'QdmiDriver' object has no attribute 'get_last_job_timing'
native   unavailable: AttributeError: 'IQMServiceClient' object has no attribute 'get_last_job_timing'
```

**The DEFw bootstrap.** They reached `svc_lib_qpm` before importing `defw`. DEFw's bootstrap is what puts its `python/service-apis` directory on `sys.path`, and anything under `svc_lib_qpm` imports `api_events` on the way in, so the import failed before any measurement ran.

`import defw` goes at module scope in `measurement_support`, which both scripts load first, rather than inside `driver_for`: the scripts resolve a descriptor before they ever build a driver, so a late import is too late.

## Testing

Run against the ORNL 20-qubit device.

Execution, one qubit at 10 shots, returns the expected all-ones counts through all three paths:

```
  library         prep      submit        wait       fetch       total
  qrmi         72.1 ms    142.4 ms    507.2 ms    305.6 ms   1027.4 ms
  qdmi         63.4 ms   1404.4 ms   1921.7 ms    508.1 ms   3897.5 ms
  native     1974.8 ms    514.4 ms   1930.1 ms    507.3 ms   4926.6 ms
```

Introspection reports the same cold/warm split as before: QRMI pays its round trips at the first call, QDMI at open.

Note these numbers were taken over an SSH tunnel from outside ORNL, so per-connection costs are inflated. They are here to show the scripts run, not as a measurement of record.
