### PR TITLE
QFw: restore QDMI on the task timing and metadata calls (release/v0.1)

### DIFF
--- a/services/svc_lib_qpm/descriptor.py
+++ b/services/svc_lib_qpm/descriptor.py
@@ -12,8 +12,8 @@ DEFAULT_CAPS = {
 	# Execution is composable for the QRMI-vs-QDMI comparison: no lib routes to
 	# the execution owner (qrmi); --lib qdmi runs the same circuit through QDMI.
 	"run_circuit": ["qrmi", "qdmi"],
-	"get_task_timing": ["qrmi"],
-	"get_task_metadata": ["qrmi"],
+	"get_task_timing": ["qrmi", "qdmi"],
+	"get_task_metadata": ["qrmi", "qdmi"],
 }
 
 DEFAULT_LIBRARIES = ["qrmi", "qdmi"]

--- a/services/svc_lib_qpm/drivers/qdmi_driver.py
+++ b/services/svc_lib_qpm/drivers/qdmi_driver.py
@@ -42,8 +42,8 @@ class QdmiDriver(BaseDriver):
 		"get_coupling_graph",
 		"get_calibration_snapshot",
 		"run_circuit",
-		"get_last_job_timing",
-		"get_last_job_metadata",
+		"get_task_timing",
+		"get_task_metadata",
 	})
 
 	def __init__(self, descriptor=None):
@@ -298,7 +298,7 @@ class QdmiDriver(BaseDriver):
 					f"QDMI job timed out after {timeout}s (status {state!r})")
 			time.sleep(max(poll, 0.0))
 
-	# --- last-job timing / metadata (from the cached run_circuit job) ----
+	# --- task timing / metadata (from the cached run_circuit job) -------
 
 	def _last_job_for(self, cid):
 		job = self._last_job
@@ -310,7 +310,7 @@ class QdmiDriver(BaseDriver):
 				f"{job.get('cid')!r})")
 		return job
 
-	def get_last_job_timing(self, cid=None):
+	def get_task_timing(self, cid=None):
 		job = self._last_job_for(cid)
 		return {
 			"cid": job.get("cid"),
@@ -318,7 +318,7 @@ class QdmiDriver(BaseDriver):
 			"status": job.get("status"),
 			"timing": job.get("timing") or {}}
 
-	def get_last_job_metadata(self, cid=None):
+	def get_task_metadata(self, cid=None):
 		job = self._last_job_for(cid)
 		return {
 			"cid": job.get("cid"),


### PR DESCRIPTION
Release-branch companion to #39. Same branch, same commit, based against `release/v0.1`.

`main` and `release/v0.1` are the same commit (`bc46b0c`) right now, so this lands the identical commit object on both branches rather than a cherry-picked duplicate with a different SHA. Please merge or rebase rather than squash, so the two branches stay comparable.

See #39 for the full description and testing. Summary: the QDMI driver kept `get_last_job_timing`/`get_last_job_metadata` after the contract renamed them to `get_task_timing`/`get_task_metadata`, so routing dropped QDMI from both calls and the descriptor defaults had been narrowed to qrmi only. Verified against the ORNL 20-qubit device.
