### PR TITLE
QFw: repair the shim measurement scripts for the v0.1 runtime (release/v0.1)

### DIFF
--- a/examples/measure_shim_execution.py
+++ b/examples/measure_shim_execution.py
@@ -140,7 +140,7 @@ def measure_library(library, device_id, args, count_port=None):
 		# The drivers time submit/wait/fetch from their own clock, started just
 		# before submission. Anything before that -- transcode and payload
 		# assembly -- is the difference against the total measured here.
-		driver_timing = (driver.get_last_job_timing() or {}).get("timing") or {}
+		driver_timing = (driver.get_task_timing() or {}).get("timing") or {}
 		submit = driver_timing.get("submit_seconds")
 		wait = driver_timing.get("wait_seconds")
 		fetch = driver_timing.get("result_fetch_seconds")

--- a/examples/measurement_support.py
+++ b/examples/measurement_support.py
@@ -10,6 +10,10 @@ import sys
 import time
 from urllib.parse import urlsplit
 
+# DEFw's bootstrap is what puts its python/service-apis on sys.path. Anything
+# under svc_lib_qpm reaches api_events on import, so this has to come first.
+import defw  # noqa: E402,F401
+
 
 class MeasurementError(Exception):
 	"""A sample was taken but cannot be trusted."""
@@ -229,13 +233,13 @@ class NativeAdapter:
 
 	`svc_iqm_qpm.util_iqm.IQMServiceClient` already exposes get_device_info,
 	get_coupling_graph, get_calibration_snapshot, run_circuit and
-	get_last_job_timing. Two return shapes differ, so they are adapted here
+	get_task_timing. Two return shapes differ, so they are adapted here
 	rather than by touching the native service, which is deliberately
 	unmodified by the shim work:
 
 	  run_circuit          returns {"counts", "qhw_result"}; the drivers return
 	                       the qhw record directly.
-	  get_last_job_timing  returns an iqm-timing-summary-v1 record whose
+	  get_task_timing      returns an iqm-timing-summary-v1 record whose
 	                       client-side spans live under "client_wall_seconds".
 
 	That second difference is worth more than the adaptation. The native record
@@ -271,8 +275,8 @@ class NativeAdapter:
 			return out["qhw_result"]
 		return out
 
-	def get_last_job_timing(self, cid=None):
-		summary = self._client.get_last_job_timing(cid) or {}
+	def get_task_timing(self, cid=None):
+		summary = self._client.get_task_timing(cid) or {}
 		self._last_summary = summary
 		wall = summary.get("client_wall_seconds") or {}
 		return {"timing": {


### PR DESCRIPTION
Release-branch companion to #41. Same branch, same commit, based against `release/v0.1`.

`main` and `release/v0.1` are the same commit (`bc46b0c`) right now, so this lands the identical commit object on both branches rather than a cherry-picked duplicate with a different SHA. Please merge or rebase rather than squash, so the two branches stay comparable.

See #41 for the full description and testing. Summary: both shim measurement scripts called the renamed `get_last_job_timing`, which broke all three arms including the native client, and they reached `svc_lib_qpm` before importing `defw`, whose bootstrap is what puts `python/service-apis` on `sys.path`. Verified against the ORNL 20-qubit device.
