### PR TITLE
QFw: fix two install-tree packaging gaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,13 +176,13 @@ install(DIRECTORY services/
 		PATTERN "*.in"
 		PATTERN "dev-config" EXCLUDE
 		PATTERN "__pycache__" EXCLUDE)
-install(CODE
-	"file(REMOVE_RECURSE \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/qfw/service-apis/api_qpm\")")
 install(DIRECTORY service-apis/
 	DESTINATION "${CMAKE_INSTALL_LIBDIR}/qfw/service-apis"
 	FILES_MATCHING
 		PATTERN "*.py"
 		PATTERN "__pycache__" EXCLUDE)
+install(CODE
+	"file(REMOVE_RECURSE \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/qfw/service-apis/api_qpm\")")
 install(DIRECTORY share/qfw/
 	DESTINATION "${CMAKE_INSTALL_DATADIR}/qfw")
 install(CODE

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -19,6 +19,7 @@ numpy
 scipy
 pyscf
 PyYAML
+jsonschema>=4
 netifaces
 psutil
 paramiko


### PR DESCRIPTION
## What

Two independent packaging problems in the CMake install, both hit while bringing an installed QFw up on the v0.1 line.

### Missing `jsonschema`

The bundled QHW packages are installed into site-packages by copying their source directories, so pip never resolves the dependencies their `pyproject.toml` files declare. `qhw-data` declares `jsonschema>=4`, and nothing installed it, so building a qhw record failed at runtime:

```
RuntimeError: jsonschema is required for schema validation
```

Added to `setup/requirements.txt`, where the rest of the resolved runtime dependencies live.

Worth noting the general shape of this: any dependency declared by a bundled QHW package is currently invisible to the install. `jsonschema` is the one that bites today, but the same gap will reappear if another bundled package grows a dependency.

### The `api_qpm` cleanup can never fire

`install(CODE file(REMOVE_RECURSE .../service-apis/api_qpm))` is declared *before* the `install(DIRECTORY service-apis/)` that recreates it. Install rules run in declaration order, so the cleanup runs and is then immediately undone.

It only shows up on a source tree carrying a leftover `api_qpm` directory, for example an empty one holding just `__pycache__` after the package was removed. `install(DIRECTORY)` recreates the directory structure even when `FILES_MATCHING` selects nothing inside it, so the empty directory reappears on every install. Python then treats it as a namespace package, and DEFw's service scan dies:

```
AttributeError: module 'api_qpm' has no attribute 'svc_info'
```

Moving the cleanup after the install that recreates it makes it do what it was written to do.

## Testing

Reproduced the failure by recreating a stale `service-apis/api_qpm/__pycache__` in the source tree and reinstalling. Before the change the empty directory came back on every install. After it, it no longer survives. The shim imports cleanly and `jsonschema` resolves in the install tree.
