### PR TITLE
QFw: fix two install-tree packaging gaps (release/v0.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,13 +176,13 @@ install(DIRECTORY services/
 		PATTERN "*.in"
 		PATTERN "dev-config" EXCLUDE
 		PATTERN "__pycache__" EXCLUDE)
-install(CODE
-	"file(REMOVE_RECURSE \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/qfw/service-apis/api_qpm\")")
 install(DIRECTORY service-apis/
 	DESTINATION "${CMAKE_INSTALL_LIBDIR}/qfw/service-apis"
 	FILES_MATCHING
 		PATTERN "*.py"
 		PATTERN "__pycache__" EXCLUDE)
+install(CODE
+	"file(REMOVE_RECURSE \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/qfw/service-apis/api_qpm\")")
 install(DIRECTORY share/qfw/
 	DESTINATION "${CMAKE_INSTALL_DATADIR}/qfw")
 install(CODE

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -19,6 +19,7 @@ numpy
 scipy
 pyscf
 PyYAML
+jsonschema>=4
 netifaces
 psutil
 paramiko


### PR DESCRIPTION
Release-branch companion to #44. Same branch, same commit, based against `release/v0.1`.

`main` and `release/v0.1` are the same commit (`bc46b0c`) right now, so this lands the identical commit object on both branches rather than a cherry-picked duplicate with a different SHA. Please merge or rebase rather than squash, so the two branches stay comparable.

See #44 for the full description and testing. Summary: `jsonschema` is declared by the bundled `qhw-data` package but never installed, because the bundled QHW packages are copied into site-packages rather than pip-installed, so their declared dependencies are not resolved. Separately, the `api_qpm` cleanup rule is declared before the `install(DIRECTORY service-apis/)` that recreates it, so it can never take effect.
