### PR TITLE
QFw: expose the shim capability map on the telemetry API (release/v0.1)

### DIFF
--- a/service-apis/api_qpm_telemetry/api_qpm_telemetry.py
+++ b/service-apis/api_qpm_telemetry/api_qpm_telemetry.py
@@ -20,6 +20,9 @@ class QPMTelemetry(QPMRemoteBase):
 			       token=None):
 		pass
 
+	def capability_map(self, token=None):
+		pass
+
 	def get_telemetry_access_model(self, token=None):
 		pass
 

--- a/services/svc_lib_qpm/svc_qpm.py
+++ b/services/svc_lib_qpm/svc_qpm.py
@@ -38,7 +38,7 @@ class QPM(UTIL_QPM):
 		info['qfw_backend'] = 'iqm'
 		return info
 
-	def capability_map(self):
+	def capability_map(self, token=None):
 		return self.qrc.capability_map()
 
 	def get_backend_info(self, lib=None, token=None):


### PR DESCRIPTION
Release-branch companion to #40, which is now merged to `main`. Same branch, same commit (`2b7de44`), based against `release/v0.1`.

This is the last piece of divergence between the two branches. Right now `git diff upstream/release/v0.1 upstream/main` reports exactly these two files and nothing else, so merging this brings the trees back into agreement.

As with #42, #43 and #45: please **merge or rebase rather than squash**, so the identical commit object lands on both branches instead of a duplicate with a different SHA.

See #40 for the full description. Summary: `capability_map` survived the QPM API split on the shim QPM, `svc_qrc` and the frontend, but was declared on no category API class. Since `BaseRemote` resolves methods with `object.__getattribute__`, an undeclared method is not reachable over RPC at all, which left the shim's per-resource gap map invisible to clients. This declares it on `QPMTelemetry` and accepts `token` on the service method to match the other telemetry calls.
