### PR TITLE
QFw: install PyYAML for ci-mock and report a missing yaml honestly

### DIFF
--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -79,7 +79,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install pytest
-      run: python -m pip install --upgrade pip pytest
+      # PyYAML is needed as well: the mock suite drives example scripts whose
+      # preflight parses the site and device-access YAML, so without it
+      # tests/mock/test_iqm_chem_driver_script.py fails on a missing module.
+      run: python -m pip install --upgrade pip pytest pyyaml
 
     - name: Run ci-mock
       # The ci-mock helper mirrors the CI-safe mock pytest suite.

--- a/examples/qfw_iqm_chem_driver.sh
+++ b/examples/qfw_iqm_chem_driver.sh
@@ -106,7 +106,11 @@ import os
 import sys
 from pathlib import Path
 
-import yaml
+try:
+	import yaml
+except ImportError as exc:
+	raise SystemExit(
+		f"ERROR: PyYAML is required to read the site configuration: {exc}")
 
 site_path = Path(sys.argv[1]).expanduser().resolve()
 prefix = sys.argv[2]


### PR DESCRIPTION
## The bug

`ci-mock` has been red on every branch since the v0.1 line landed, always on the same test: `tests/mock/test_iqm_chem_driver_script.py::test_service_run_dir_overrides_environment_site_config`.

The job installs only pytest:

```yaml
run: python -m pip install --upgrade pip pytest
```

But the mock suite drives `examples/qfw_iqm_chem_driver.sh`, whose preflight parses the site and device-access YAML with `python3`. Without PyYAML the script exits 2 and the test fails. It passes in any normal QFw environment, which is why the failure looked environmental and went unexplained.

Reproduced by running the script against a `python3` with no yaml:

```
ModuleNotFoundError: No module named 'yaml'
ERROR: site device-access configuration is required for owner preflight
EXIT CODE = 2
```

That is exactly the `exit status 2` CI reports.

## Why this is worth fixing now rather than later

`test-release.yml` runs this same reusable workflow on a `v*` tag, and gates the release on it:

```yaml
create_release:
  needs: [test]
```

So tagging a release today fails the test job and **never publishes the release**. This is a release blocker, not just a red check.

## The second change

`qfw_chem_driver_device_access_config` imported yaml unguarded, so a missing module produced a bare traceback and the caller then reported *"site device-access configuration is required for owner preflight"* — blaming configuration when the real cause was a missing dependency. That misdirection cost real debugging time.

`qfw_chem_driver_preflight_owner` already guards its own import and reports properly. This applies the same pattern to the other one, so the first line of output names the actual problem:

```
ERROR: PyYAML is required to read the site configuration: No module named 'yaml'
```

No behaviour change when PyYAML is present.

## Testing

- `tests/mock`: 195 passed, 1 skipped
- `ci-syntax`: passes
- Reproduced the original failure, applied the fix, confirmed the message now leads with the real cause
- Also ran the suites CI does not cover, `tests/test_qfw_runtime_*` (28 passed) and `tests/qiskit` (1 passed), both clean

## Note on the release branch

There are **no workflow runs at all against `release/v0.1`** — the workflows cover main, pull requests, and tags only. So that branch can drift red unnoticed until tag time, which is roughly what happened here. Adding it to the push triggers would be a small change, but it affects the whole repo's CI so I left it out of this PR.
